### PR TITLE
Add new technical diagram to the README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,9 +550,9 @@ they relate to one another. You can see that for each implementation there is
 also a blue noise variant. More on this below.
 
 <picture>
-  <source media="(prefers-color-scheme: light)" srcset="./images/diagrams/implementation-diagram-light.png">
-  <source media="(prefers-color-scheme: dark)" srcset="./images/diagrams/implementation-diagram-dark.png">
-  <img alt="High level implementation diagram." src="./images/diagrams/implementation-diagram-light.png">
+  <source media="(prefers-color-scheme: light)" srcset="./images/diagrams/high-level-overview-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="./images/diagrams/high-level-overview-dark.png">
+  <img alt="High level implementation diagram." src="./images/diagrams/high-level-overview-light.png">
 </picture>
 
 ### Rate of convergence
@@ -655,6 +655,12 @@ Sobol implementation. However as the sequence doesn't extend to more than two
 dimensions, the second pair is randomised relative to the first in a single
 domain.
 
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="./images/diagrams/pmj-design-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="./images/diagrams/pmj-design-dark.png">
+  <img alt="Pmj pair plot." src="./images/diagrams/pmj-design-light.png">
+</picture>
+
 This sampler pre-computes a base 4D pattern for all sample indices during the
 cache initialisation. Permuted index values are then looked up from memory at
 runtime, before being XOR scrambled. This amortises the cost of initialisation.
@@ -676,6 +682,12 @@ limiting the index to 16 bits, pre-inverting the input and output matrices, and
 making use of CPU vector intrinsics. You need to select an `OPENQMC_ARCH_TYPE`
 to make use of the performance from vector intrinsics for a given architecture.
 
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="./images/diagrams/sobol-design-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="./images/diagrams/sobol-design-dark.png">
+  <img alt="sobol pair plot." src="./images/diagrams/sobol-design-light.png">
+</picture>
+
 This sampler has no cache initialisation cost, it generates all samples on the
 fly without touching memory. However the cost per draw sample call is
 computationally higher than other samplers. The quality of Owen scramble
@@ -695,6 +707,12 @@ construct a 4D lattice. This is then made into a progressive sequence using
 a scalar based on a radical inversion of the sample index. Randomisation uses
 toroidal shifts.
 
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="./images/diagrams/lattice-design-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="./images/diagrams/lattice-design-dark.png">
+  <img alt="lattice pair plot." src="./images/diagrams/lattice-design-light.png">
+</picture>
+
 This sampler has no cache initialisation cost, it generates all samples on the
 fly without touching memory. Runtime performance is also high with a relatively
 low computation cost for a single draw sample call. However the rate of
@@ -713,11 +731,23 @@ pixels, with progressive ranking for progressive pixel sampling. This involves
 an offline optimisation process that's based on the work by Belcour and Heitz
 [^4], and extends temporally as described by Wolfe et al. [^5].
 
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="./images/diagrams/optimise-index-seed-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="./images/diagrams/optimise-index-seed-dark.png">
+  <img alt="lattice pair plot." src="./images/diagrams/optimise-index-seed-light.png">
+</picture>
+
 Each variant achieves a blue noise distribution using two pixel tables, one
 holds keys to seed the sequence, and the other index ranks. These tables are
 then randomised by toroidally shifting the table lookups for each domain using
 random offsets. Correlation between the offsets and the pixels allows for a
 single pair of tables to provide keys and ranks for many domains.
+
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="./images/diagrams/blue-noise-procedure-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="./images/diagrams/blue-noise-procedure-dark.png">
+  <img alt="lattice pair plot." src="./images/diagrams/blue-noise-procedure-light.png">
+</picture>
 
 Although the spatial temporal blue noise doesn't reduce the error for an
 individual pixel, it does give a better perceptual result due to less low

--- a/images/diagrams/blue-noise-procedure-dark.png
+++ b/images/diagrams/blue-noise-procedure-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:935d5c3930dee3377cbb8e37fdaf95237fa420e4236f486d8dc5ceab70b93f9c
+size 178598

--- a/images/diagrams/blue-noise-procedure-light.png
+++ b/images/diagrams/blue-noise-procedure-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df16167d1e2eb76bc463a9c13ca91e7dbd98960de8818813803b9e02049af8a9
+size 179358

--- a/images/diagrams/high-level-overview-dark.png
+++ b/images/diagrams/high-level-overview-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23c57162522c3d0c875eb6e219e2fa792078c7513626e874fd6faa5f2e5cdb1a
+size 200587

--- a/images/diagrams/high-level-overview-light.png
+++ b/images/diagrams/high-level-overview-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c087947d2bddc2740da8bd9db9c0ba37e38c2c10fa7886b99798f6741f6646
+size 200876

--- a/images/diagrams/implementation-diagram-dark.png
+++ b/images/diagrams/implementation-diagram-dark.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5300230d2546bc50654d28cea003b6070f2df4283067fc60db38a57fe8f77ef
-size 201842

--- a/images/diagrams/implementation-diagram-light.png
+++ b/images/diagrams/implementation-diagram-light.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c91dad37df4e3dcfaa55901a513f4b7f9be4061321a774cdb84fbd8e3073fcf
-size 201335

--- a/images/diagrams/lattice-design-dark.png
+++ b/images/diagrams/lattice-design-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:598c49190a2d9eb4b71ba33c9ffe3592b45f0413972a5656dad7decd35b80e2d
+size 105461

--- a/images/diagrams/lattice-design-light.png
+++ b/images/diagrams/lattice-design-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a00cedf72fb174a6599bb531334c27a730502972900638d7a32d3f9328b35055
+size 105901

--- a/images/diagrams/optimise-index-seed-dark.png
+++ b/images/diagrams/optimise-index-seed-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:476bf14c16d9b34deac75a9e62160903e586a2600221ccee21935bbea6d33f27
+size 124166

--- a/images/diagrams/optimise-index-seed-light.png
+++ b/images/diagrams/optimise-index-seed-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab37dafaea4cd8a1dec920287841ea8f21e9b9757ddacdff16dc8e9ec62021ba
+size 124694

--- a/images/diagrams/pmj-design-dark.png
+++ b/images/diagrams/pmj-design-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4852d42ea54814ba2fd41d61fd71e0dd7ceddaedb9ebdd7b539d742f1a1a5aa
+size 150158

--- a/images/diagrams/pmj-design-light.png
+++ b/images/diagrams/pmj-design-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68b58861399161319d2b8f9695b75b1dcd12464c14167d8d2ae48da6f9e462d9
+size 150485

--- a/images/diagrams/sobol-design-dark.png
+++ b/images/diagrams/sobol-design-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64549325eabb307cc4cdda66c3fc7ad6e5b01f5cf79eb75a174857f2f941b9b2
+size 112515

--- a/images/diagrams/sobol-design-light.png
+++ b/images/diagrams/sobol-design-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20778a5c9d30c97b75c5aa390161fbe350f750137b31fcb8942129849a2ffdc2
+size 112953


### PR DESCRIPTION
Some of the technical details that were in written form on the README page could be aided by a visual representation.

Add diagrams for each implementation, as well as a couple more for breaking down the blue noise process.