### PR TITLE
Add README documentation for domain branching

### DIFF
--- a/images/diagrams/domain-tree-graph-1.png
+++ b/images/diagrams/domain-tree-graph-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e28f337a5626167649635e72ea2528ddfe2657d524df4793952ddc2efb91602b
+size 810103

--- a/images/diagrams/domain-tree-graph-2.png
+++ b/images/diagrams/domain-tree-graph-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c97263bb9877c4895c71ec2e9aeb161f7d261a6cefb6f797cce917ad5feaedc1
+size 815080

--- a/images/diagrams/domain-tree-graph-3.png
+++ b/images/diagrams/domain-tree-graph-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68c00d845113a4e77311a69aa7c16a7d32681e28abce515f8022ae6446a387a6
+size 808521

--- a/images/diagrams/domain-tree-graph-4.png
+++ b/images/diagrams/domain-tree-graph-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8639d3dee74ab3908879a290fa45634c8ec901dbc825c1cde9287e5f31c24941
+size 1182048

--- a/images/diagrams/domain-tree-graph-5.png
+++ b/images/diagrams/domain-tree-graph-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cc0d283eef7acc636d075af4f33ed94a2d571be344651ee80ed624e01d24566
+size 1132338


### PR DESCRIPTION
We needed further work done on explaining the domain branching model, and the problems it resolved. This also requires some visual aids to make the concepts easier to grock.

Add new content to the README page under the 'Domain branching' section along with some diagrams to explain the idea behind each example. Also do some general cleaning up of the README.