### PR TITLE
Add an inital logo design for the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# OpenQMC
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="./images/openqmc-logo-light.png">
+    <source media="(prefers-color-scheme: dark)" srcset="./images/openqmc-logo-dark.png">
+    <img alt="OpenQMC" src="./images/openqmc-logo-light.png" height="200">
+  </picture>
+</p>
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-informational)](https://github.com/framestore/openqmc/blob/main/LICENSE)
 [![Version](https://img.shields.io/github/v/release/framestore/openqmc)](https://github.com/framestore/openqmc/releases/latest)

--- a/images/openqmc-logo-dark.png
+++ b/images/openqmc-logo-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:664cc1b9990226f9044501d15652429a73ceb7b58f05fddec84d03e9b567fc14
+size 116827

--- a/images/openqmc-logo-light.png
+++ b/images/openqmc-logo-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7b4d4f68ea9cdbae903b6113728297d3420aaaae1abaf56ca5bd483d53f8f3f
+size 112679


### PR DESCRIPTION
We wanted to develop a logo for the project and had an initial design. This might change, but can be added non the less to the README page now.

Add two images for light and dark themed browsers. And replace current title with picture block.