### PR TITLE
Load clang-tools before clang in nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,23 +20,38 @@
             pkgs.cmake
           ];
         };
-        devShells.default = pkgs.mkShell {
+        devShells.default = pkgs.mkShell.override {
+          stdenv = pkgs.stdenvNoCC;
+        } {
           name = "devshell";
           packages = [
+            pkgs.clang-tools
+            pkgs.clang
+            pkgs.git
             pkgs.cmakeCurses
             pkgs.ninja
             pkgs.just
             pkgs.glm
             pkgs.gtest
             pkgs.tbb_2021_8
-            pkgs.python310Packages.jupyter
-            pkgs.python310Packages.matplotlib
-            pkgs.python310Packages.numpy
-            pkgs.python310Packages.pillow
             hypothesis.packages.${system}.default
           ];
           inputsFrom = [
             self.packages.${system}.default
+          ];
+        };
+        devShells.notebook = pkgs.mkShell.override {
+          stdenv = pkgs.stdenvNoCC;
+        } {
+          name = "notebook";
+          packages = [
+            pkgs.python310Packages.jupyter
+            pkgs.python310Packages.matplotlib
+            pkgs.python310Packages.numpy
+            pkgs.python310Packages.pillow
+          ];
+          inputsFrom = [
+            self.devShells.${system}.default
           ];
           shellHook = ''
             export TOOLSPATH=$PWD/build/src/tools/lib


### PR DESCRIPTION
Clang tools that are included with CC on macOS don't have the needed wrappers to handle include paths, makeing clang-tidy etc non-functional.

For the devshell (which will be used for CI), load the stdenv without CC. Then add clang-tools prior to adding back clang, so that it takes priority. This allows the clang-tidy package to include wrappers.