### PR TITLE
Update the flake inputs to a new version of nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -20,7 +20,9 @@
     },
     "hypothesis": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1685198809,
@@ -38,26 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685197980,
-        "narHash": "sha256-u6W8iBS+cbOIM4F3Eqs0E0S3kKScP25S1FRDEHaN3YQ=",
+        "lastModified": 1688338269,
+        "narHash": "sha256-s1HQDDIDcW5rmcekdvtIw4PPQSHBknxr/6JX3LVRoEA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ed1a9b311c22b971ae17a96853340b8e5be8914",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1685230126,
-        "narHash": "sha256-OWgW8n+Xl3TtPlw0fI8Pv7MSN5g1nMGQoTTPrDj0nHk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f0d82460d2cfa7922df6c2852a583504ad75eed2",
+        "rev": "6b6a753d4732d2516aa64166845675e96c67ee98",
         "type": "github"
       },
       "original": {
@@ -70,7 +57,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "hypothesis": "hypothesis",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     hypothesis.url = "github:joshbainbridge/hypothesis";
+    hypothesis.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, flake-utils, hypothesis }:


### PR DESCRIPTION
For security reasons its advisied to keep flakes inputs updated. After running the Nix Flake Checker, the nixpkgs version was shown to be older than 30 days.

Set the hypothesis input to follow the projects top level nixpkgs so that it can be updated. Then update the common nixpkgs version used for all derivatives.