### PR TITLE
Format python code using Black and add LSP support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -40,15 +40,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688338269,
-        "narHash": "sha256-s1HQDDIDcW5rmcekdvtIw4PPQSHBknxr/6JX3LVRoEA=",
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b6a753d4732d2516aa64166845675e96c67ee98",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   description = "Quasi-Monte Carlo sampling library for rendering and graphics applications";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/23.05";
     flake-utils.url = "github:numtide/flake-utils";
     hypothesis.url = "github:joshbainbridge/hypothesis";
     hypothesis.inputs.nixpkgs.follows = "nixpkgs";
@@ -46,6 +46,8 @@
         } {
           name = "notebook";
           packages = [
+            pkgs.python310Packages.python-lsp-server
+            pkgs.python310Packages.python-lsp-ruff
             pkgs.python310Packages.jupyter
             pkgs.python310Packages.matplotlib
             pkgs.python310Packages.numpy

--- a/python/utility.py
+++ b/python/utility.py
@@ -6,20 +6,21 @@ import matplotlib.pyplot as plt
 import numpy as np
 import wrapper as oqmc
 
-sequences_base = ('pmj', 'sobol', 'lattice')
-sequences_complete = ('pmj', 'pmjbn', 'sobol', 'sobolbn', 'lattice', 'latticebn')
+sequences_base = ("pmj", "sobol", "lattice")
+sequences_complete = ("pmj", "pmjbn", "sobol", "sobolbn", "lattice", "latticebn")
 
 shapes = {
-    'qdisk' : 'quarter disk',
-    'qgauss' : 'quarter gaussian',
-    'bilin' : 'bilinear',
-    'heavi' : 'orientated heaviside',
+    "qdisk": "quarter disk",
+    "qgauss": "quarter gaussian",
+    "bilin": "bilinear",
+    "heavi": "orientated heaviside",
 }
 
-def save_light_dark_figure(id, function, *args, **kwargs):
-    options = {'light' : 'default', 'dark' : 'dark_background'}
 
-    variable_name = 'SAVEPLOT'
+def save_light_dark_figure(id, function, *args, **kwargs):
+    options = {"light": "default", "dark": "dark_background"}
+
+    variable_name = "SAVEPLOT"
     if variable_name not in os.environ:
         function(*args, **kwargs)
         return
@@ -33,10 +34,10 @@ def save_light_dark_figure(id, function, *args, **kwargs):
         plt.style.use(style)
 
     def build_path(name, type):
-        return '../../images/plots/{}-{}.png'.format(name, type)
+        return "../../images/plots/{}-{}.png".format(name, type)
 
     def save_figure(path):
-        plt.savefig(path, dpi=200, bbox_inches = "tight", transparent=True)
+        plt.savefig(path, dpi=200, bbox_inches="tight", transparent=True)
 
     use_style(options[variable_value])
 
@@ -44,14 +45,19 @@ def save_light_dark_figure(id, function, *args, **kwargs):
 
     save_figure(build_path(id, variable_value))
 
+
 def disable_tick(tick):
     tick.tick1line.set_visible(False)
     tick.tick2line.set_visible(False)
     tick.label1.set_visible(False)
     tick.label2.set_visible(False)
 
+
 def eotf_inverse_sRGB(image):
-    return np.where(image <= 0.0031308, image * 12.92, ((image ** (1 / 2.4)) * 1.055) - 0.055)
+    return np.where(
+        image <= 0.0031308, image * 12.92, ((image ** (1 / 2.4)) * 1.055) - 0.055
+    )
+
 
 def get_shape(shape):
     nsamples = 32
@@ -63,8 +69,9 @@ def get_shape(shape):
 
     return image
 
-def get_image(sequence, max_depth, num_pixel_samples = 2):
-    scene = b'box'
+
+def get_image(sequence, max_depth, num_pixel_samples=2):
+    scene = b"box"
     width = 512
     height = 512
     frame = 0
@@ -72,7 +79,17 @@ def get_image(sequence, max_depth, num_pixel_samples = 2):
     max_opacity = 1
     exposure = 3
 
-    image = oqmc.trace(sequence, scene, width, height, frame, num_pixel_samples, num_light_samples, max_depth, max_opacity)
+    image = oqmc.trace(
+        sequence,
+        scene,
+        width,
+        height,
+        frame,
+        num_pixel_samples,
+        num_light_samples,
+        max_depth,
+        max_opacity,
+    )
     image = image * exposure
     image = eotf_inverse_sRGB(image)
     image = np.clip(image, 0, 1)

--- a/python/wrapper.py
+++ b/python/wrapper.py
@@ -6,217 +6,278 @@ import os
 import ctypes
 import numpy as np
 
-module = np.ctypeslib.load_library('libtools', os.environ['TOOLSPATH'])
+module = np.ctypeslib.load_library("libtools", os.environ["TOOLSPATH"])
 
 module.oqmc_benchmark.restype = ctypes.c_bool
 module.oqmc_benchmark.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.POINTER(ctypes.c_int)
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.POINTER(ctypes.c_int),
 ]
 
+
 def benchmark(sampler, measurement, nsamples, ndims):
-	time = ctypes.c_int(0)
-	valid = module.oqmc_benchmark(sampler, measurement, nsamples, ndims, ctypes.byref(time))
+    time = ctypes.c_int(0)
+    valid = module.oqmc_benchmark(
+        sampler, measurement, nsamples, ndims, ctypes.byref(time)
+    )
 
-	if not valid:
-		sys.exit()
+    if not valid:
+        sys.exit()
 
-	return time.value
+    return time.value
+
 
 module.oqmc_frequency_continuous.restype = ctypes.c_bool
 module.oqmc_frequency_continuous.argtypes = [
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	np.ctypeslib.ndpointer(),
-	np.ctypeslib.ndpointer()
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    np.ctypeslib.ndpointer(),
+    np.ctypeslib.ndpointer(),
 ]
 
+
 def frequency(nsequences, nsamples, ndims, depthA, depthB, resolution, src):
-	spectrum = np.zeros((resolution, resolution), dtype=np.float32)
-	valid = module.oqmc_frequency_continuous(nsequences, nsamples, ndims, depthA,
-			depthB, resolution, src, spectrum)
+    spectrum = np.zeros((resolution, resolution), dtype=np.float32)
+    valid = module.oqmc_frequency_continuous(
+        nsequences, nsamples, ndims, depthA, depthB, resolution, src, spectrum
+    )
 
-	if not valid:
-		sys.exit()
+    if not valid:
+        sys.exit()
 
-	return spectrum
+    return spectrum
+
 
 module.oqmc_generate.restype = ctypes.c_bool
 module.oqmc_generate.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    np.ctypeslib.ndpointer(),
 ]
 
+
 def generate(name, nsequences, nsamples, ndims):
-	points = np.zeros((nsequences, nsamples, ndims), dtype=np.float32)
-	valid = module.oqmc_generate(name, nsequences, nsamples, ndims, points)
+    points = np.zeros((nsequences, nsamples, ndims), dtype=np.float32)
+    valid = module.oqmc_generate(name, nsequences, nsamples, ndims, points)
 
-	if not valid:
-		sys.exit()
+    if not valid:
+        sys.exit()
 
-	return points
+    return points
+
 
 module.oqmc_optimise.restype = ctypes.c_bool
 module.oqmc_optimise.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	np.ctypeslib.ndpointer(),
-	np.ctypeslib.ndpointer(),
-	np.ctypeslib.ndpointer(),
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    np.ctypeslib.ndpointer(),
+    np.ctypeslib.ndpointer(),
+    np.ctypeslib.ndpointer(),
+    np.ctypeslib.ndpointer(),
 ]
 
+
 def optimise(name, ntests, niterations, nsamples, resolution, depth, seed):
-	module.oqmc_progress_off()
+    module.oqmc_progress_off()
 
-	keys = np.zeros((resolution, resolution, depth), dtype=np.uint32)
-	ranks = np.zeros((resolution, resolution, depth), dtype=np.uint32)
-	estimates = np.zeros((resolution, resolution, depth), dtype=np.float32)
-	frequencies = np.zeros((resolution, resolution, depth), dtype=np.float32)
-	valid = module.oqmc_optimise(name, ntests, niterations, nsamples,
-			resolution, depth, seed, keys, ranks, estimates, frequencies)
+    keys = np.zeros((resolution, resolution, depth), dtype=np.uint32)
+    ranks = np.zeros((resolution, resolution, depth), dtype=np.uint32)
+    estimates = np.zeros((resolution, resolution, depth), dtype=np.float32)
+    frequencies = np.zeros((resolution, resolution, depth), dtype=np.float32)
+    valid = module.oqmc_optimise(
+        name,
+        ntests,
+        niterations,
+        nsamples,
+        resolution,
+        depth,
+        seed,
+        keys,
+        ranks,
+        estimates,
+        frequencies,
+    )
 
-	module.oqmc_progress_on()
+    module.oqmc_progress_on()
 
-	if not valid:
-		sys.exit()
+    if not valid:
+        sys.exit()
 
-	return [keys, ranks, estimates, frequencies]
+    return [keys, ranks, estimates, frequencies]
+
 
 module.oqmc_plot_shape.restype = ctypes.c_bool
 module.oqmc_plot_shape.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    np.ctypeslib.ndpointer(),
 ]
 
+
 def plot_shape(shape, nsamples, resolution):
-	image = np.zeros((resolution, resolution), dtype=np.float32)
-	valid = module.oqmc_plot_shape(shape, nsamples, resolution, image)
+    image = np.zeros((resolution, resolution), dtype=np.float32)
+    valid = module.oqmc_plot_shape(shape, nsamples, resolution, image)
 
-	if not valid:
-		sys.exit()
+    if not valid:
+        sys.exit()
 
-	return image
+    return image
+
 
 module.oqmc_plot_zoneplate.restype = ctypes.c_bool
 module.oqmc_plot_zoneplate.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    np.ctypeslib.ndpointer(),
 ]
 
+
 def plot_zoneplate(sampler, nsamples, resolution):
-	image = np.zeros((resolution, resolution), dtype=np.float32)
-	valid = module.oqmc_plot_zoneplate(sampler, nsamples, resolution, image)
+    image = np.zeros((resolution, resolution), dtype=np.float32)
+    valid = module.oqmc_plot_zoneplate(sampler, nsamples, resolution, image)
 
-	if not valid:
-		sys.exit()
+    if not valid:
+        sys.exit()
 
-	return image
+    return image
+
 
 module.oqmc_plot_error.restype = ctypes.c_bool
 module.oqmc_plot_error.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    np.ctypeslib.ndpointer(),
 ]
 
+
 def plot_error(shape, sampler, nsequences, nsamples):
-	errors = np.zeros((nsamples, 2), dtype=np.float32)
-	valid = module.oqmc_plot_error(shape, sampler, nsequences, nsamples, errors)
+    errors = np.zeros((nsamples, 2), dtype=np.float32)
+    valid = module.oqmc_plot_error(shape, sampler, nsequences, nsamples, errors)
 
-	if not valid:
-		sys.exit()
+    if not valid:
+        sys.exit()
 
-	return errors
+    return errors
+
 
 module.oqmc_plot_error_filter_space.restype = ctypes.c_bool
 module.oqmc_plot_error_filter_space.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_float,
-	ctypes.c_float,
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_float,
+    ctypes.c_float,
+    np.ctypeslib.ndpointer(),
 ]
 
-def plot_error_filter_space(shape, sampler, resolution, nsamples, nsigma, sigmaMin, sigmaStep):
-	errors = np.zeros((nsigma, 2), dtype=np.float32)
-	valid = module.oqmc_plot_error_filter_space(shape, sampler, resolution, nsamples, nsigma, sigmaMin, sigmaStep, errors)
 
-	if not valid:
-		sys.exit()
+def plot_error_filter_space(
+    shape, sampler, resolution, nsamples, nsigma, sigmaMin, sigmaStep
+):
+    errors = np.zeros((nsigma, 2), dtype=np.float32)
+    valid = module.oqmc_plot_error_filter_space(
+        shape, sampler, resolution, nsamples, nsigma, sigmaMin, sigmaStep, errors
+    )
 
-	return errors
+    if not valid:
+        sys.exit()
+
+    return errors
+
 
 module.oqmc_plot_error_filter_time.restype = ctypes.c_bool
 module.oqmc_plot_error_filter_time.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_float,
-	ctypes.c_float,
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_float,
+    ctypes.c_float,
+    np.ctypeslib.ndpointer(),
 ]
 
-def plot_error_filter_time(shape, sampler, resolution, depth, nsamples, nsigma, sigmaMin, sigmaStep):
-	errors = np.zeros((nsigma, 2), dtype=np.float32)
-	valid = module.oqmc_plot_error_filter_time(shape, sampler, resolution, depth, nsamples, nsigma, sigmaMin, sigmaStep, errors)
 
-	if not valid:
-		sys.exit()
+def plot_error_filter_time(
+    shape, sampler, resolution, depth, nsamples, nsigma, sigmaMin, sigmaStep
+):
+    errors = np.zeros((nsigma, 2), dtype=np.float32)
+    valid = module.oqmc_plot_error_filter_time(
+        shape, sampler, resolution, depth, nsamples, nsigma, sigmaMin, sigmaStep, errors
+    )
 
-	return errors
+    if not valid:
+        sys.exit()
+
+    return errors
+
 
 module.oqmc_trace.restype = ctypes.c_bool
 module.oqmc_trace.argtypes = [
-	ctypes.c_char_p,
-	ctypes.c_char_p,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	ctypes.c_int,
-	np.ctypeslib.ndpointer()
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    np.ctypeslib.ndpointer(),
 ]
 
-def trace(name, scene, width, height, frame, numPixelSamples, numLightSamples, maxDepth, maxOpacity):
-	module.oqmc_progress_off()
 
-	image = np.zeros((height, width, 3), dtype=np.float32)
-	valid = module.oqmc_trace(name, scene, width, height, frame, numPixelSamples,
-			numLightSamples, maxDepth, maxOpacity, image)
+def trace(
+    name,
+    scene,
+    width,
+    height,
+    frame,
+    numPixelSamples,
+    numLightSamples,
+    maxDepth,
+    maxOpacity,
+):
+    module.oqmc_progress_off()
 
-	module.oqmc_progress_on()
+    image = np.zeros((height, width, 3), dtype=np.float32)
+    valid = module.oqmc_trace(
+        name,
+        scene,
+        width,
+        height,
+        frame,
+        numPixelSamples,
+        numLightSamples,
+        maxDepth,
+        maxOpacity,
+        image,
+    )
 
-	if not valid:
-		sys.exit()
+    module.oqmc_progress_on()
 
-	return image
+    if not valid:
+        sys.exit()
+
+    return image


### PR DESCRIPTION
There is no support for python code formatting and no style has yet been applied to python code.

Format all python code based on Black. Also add python LSP support via Ruff. Ruff version has been locked against Nixpkgs 23.05, as updating to 23.11 forces an update to clang. Planning to move all dependencies upto the latest Nixpkgs in a future commit.