### PR TITLE
Add coverage checks for unit testing

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Pipeline
 
 on:
   push:

--- a/.github/workflows/coverage-pipeline.yml
+++ b/.github/workflows/coverage-pipeline.yml
@@ -1,0 +1,47 @@
+name: Coverage Pipeline
+
+on:
+  push:
+    branches: main
+
+jobs:
+  test-coverage:
+    name: Test coverage
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with: {submodules: true}
+
+      # Install and set LLVM and Clang respectively
+      - run: sudo apt-get update && sudo apt-get install llvm
+      - run: sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 50
+
+      # Configure and build test binary
+      - run: cmake --preset unix -D CMAKE_CXX_FLAGS='-fprofile-instr-generate -fcoverage-mapping'
+      - run: cmake --build --preset unix --target tests
+
+      # Run instrumented test binary and gather coverage data
+      - run: LLVM_PROFILE_FILE='build/coverage.profraw' build/src/tests/tests
+      - run: llvm-profdata merge --sparse --output build/coverage.profdata build/coverage.profraw
+      - run: llvm-cov export --instr-profile build/coverage.profdata build/src/tests/tests include > coverage.json
+      - run: llvm-cov show --instr-profile build/coverage.profdata --format html --output-dir coverage-report build/src/tests/tests include
+
+      # Extract the total function coverage percentage
+      - run: sudo apt-get update && sudo apt-get install jq
+      - run: echo "COVERAGE=$(jq '.data[0].totals.functions.percent' coverage.json)" >> $GITHUB_ENV
+
+      # Upload json data for coverage badge
+      - uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: c64d4efeaa4f0760255cc54cdadce85c
+          filename: test.json
+          label: coverage
+          message: ${{ env.COVERAGE }}%
+          valColorRange: ${{ env.COVERAGE }}
+          minColorRange: 0
+          maxColorRange: 100
+
+      # Upload coverage report artifact
+      - uses: actions/upload-artifact@v3
+        with: {name: coverage-report, path: "coverage-report"}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,20 @@ If there are errors, these should ideally be addressed prior to commiting the ch
 
 For automated diagnostic checks in your editor, make sure your development enviroment is setup to integrate both ClangTidy and Flake8. This can be done using [Language Server Protocol](https://microsoft.github.io/language-server-protocol).
 
+## Coverage
+
+Test coverage is evaluated using [llvm](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) and is run on the CI pipeline. However you can also run the check locally. First step is to add the appropiate build flags for enabling compiler instrumentation:
+
+```bash
+cmake --preset unix -D CMAKE_CXX_FLAGS='-fprofile-instr-generate -fcoverage-mapping'
+```
+
+Then follow the steps in [Testing](README.md#testing) to build the unit test binary. Once the tests are built, the instrumentation will need to run all tests to gather the coverage data, before reporting the results. You can do this last step using the following script:
+
+```bash
+./scripts/check-coverage.sh
+```
+
 ## Documentation style
 
 More general documentation outside of code itself follows the [Google developer documentation style guide](https://developers.google.com/style). Contributors should see this as a guide and not a list of rules. Strict compliance to the guide isn't required and isn't validated during the CI process. It's instead up to the PR process to make sure documentation is up to date and of high quality.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-informational)](https://github.com/framestore/openqmc/blob/main/LICENSE)
 [![Version](https://img.shields.io/github/v/release/framestore/openqmc)](https://github.com/framestore/openqmc/releases/latest)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/joshbainbridge/c64d4efeaa4f0760255cc54cdadce85c/raw/test.json)
 [![CI](https://github.com/framestore/openqmc/workflows/ci/badge.svg)](https://github.com/framestore/openqmc/actions?query=branch%3Amain)
 
 OpenQMC is a library for sampling high quality Quasi-Monte Carlo (QMC) points

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           name = "devshell";
           packages = [
             pkgs.cmakeCurses
+            pkgs.llvm
             pkgs.clang-tools
             pkgs.clang
             pkgs.ninja

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the OpenQMC Project.
+
+#!/bin/bash
+set -e
+
+LLVM_PROFILE_FILE='build/coverage.profraw' build/src/tests/tests
+llvm-profdata merge --sparse --output build/coverage.profdata build/coverage.profraw
+llvm-cov report --instr-profile build/coverage.profdata build/src/tests/tests include


### PR DESCRIPTION
There is no support for checking test coverage across the project.
Having this would allow develops to get a clearer insight into the
health of the projects unit testing, as well as guide where testing
is needed.

Add a new CI pipeline that runs on main to produce a coverage badge and
a html report for detailed insight. Also update the nix enviroment with
LLVM and provide a helper script to check coverage locally. Instructions
on how to do so have been added to the CONTRIBUTING.md file.