### PR TITLE
Update README badges to follow latest GH docs

### DIFF
--- a/.github/workflows/coverage-pipeline.yml
+++ b/.github/workflows/coverage-pipeline.yml
@@ -36,7 +36,7 @@ jobs:
           auth: ${{ secrets.GIST_SECRET }}
           gistID: c64d4efeaa4f0760255cc54cdadce85c
           filename: test.json
-          label: coverage
+          label: Coverage
           message: ${{ env.COVERAGE }}%
           valColorRange: ${{ env.COVERAGE }}
           minColorRange: 0

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
   </picture>
 </p>
 
-[![License](https://img.shields.io/badge/license-Apache--2.0-informational)](https://github.com/framestore/openqmc/blob/main/LICENSE)
-[![Version](https://img.shields.io/github/v/release/framestore/openqmc)](https://github.com/framestore/openqmc/releases/latest)
+[![License](https://img.shields.io/badge/License-Apache--2.0-informational)](https://github.com/framestore/openqmc/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/framestore/openqmc?label=Release)](https://github.com/framestore/openqmc/releases/latest)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/joshbainbridge/c64d4efeaa4f0760255cc54cdadce85c/raw/test.json)
-[![CI](https://github.com/framestore/openqmc/workflows/ci/badge.svg)](https://github.com/framestore/openqmc/actions?query=branch%3Amain)
+[![CI Pipeline](https://github.com/framestore/openqmc/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/framestore/openqmc/actions/workflows/ci-pipeline.yml)
 
 OpenQMC is a library for sampling high quality Quasi-Monte Carlo (QMC) points
 and generating pseudo random numbers. Designed for graphics applications,


### PR DESCRIPTION
The badge address used for the CI pipeline was not the address now recomended in the GitHub documentation.

Update the badge address for the CI pipeline along with all other badges to keep a consistent style.