### PR TITLE
Add header to the COMMITTERS.csv file

### DIFF
--- a/COMMITTERS.csv
+++ b/COMMITTERS.csv
@@ -1,3 +1,4 @@
+Name, Email, GitHub ID
 Josh Bainbridge, josh.bainbridge@gmail.com, @joshbainbridge
 Jose Esteve, jose.esteve@framestore.com, @joesfer
 Chris Haldane, chris.haldane@framestore.com, @chaldane


### PR DESCRIPTION
There was missing header information for the COMMITTERS.csv file to detail the name of each column.

Add the missing information including Name, Email Address, and GitHub ID.