### PR TITLE
Add support for Windows OS

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -97,7 +97,7 @@ jobs:
     needs: test-unit
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, self-hosted]
+        os: [ubuntu-22.04, macos-12, windows-2022, self-hosted]
         arch: [Scalar, SSE, AVX, ARM, GPU]
         build: [Release, Debug]
         exclude:
@@ -106,18 +106,22 @@ jobs:
           - {os: macos-12, arch: AVX}
           - {os: macos-12, arch: ARM}
           - {os: macos-12, arch: GPU}
+          - {os: windows-2022, arch: ARM}
+          - {os: windows-2022, arch: GPU}
           - {os: self-hosted, arch: Scalar}
           - {os: self-hosted, arch: SSE}
           - {os: self-hosted, arch: AVX}
         include:
-          - {os: ubuntu-22.04, save: true}
-          - {os: self-hosted, save: true}
+          - {os: ubuntu-22.04, preset: unix, save: true}
+          - {os: macos-12, preset: unix}
+          - {os: windows-2022, preset: windows}
+          - {os: self-hosted, preset: unix, save: true}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with: {submodules: true}
-      - run: cmake --preset unix -D OPENQMC_ARCH_TYPE=${{ matrix.arch }} -D CMAKE_BUILD_TYPE=${{ matrix.build }}
-      - run: cmake --build --preset unix
+      - run: cmake --preset ${{ matrix.preset }} -D OPENQMC_ARCH_TYPE=${{ matrix.arch }} -D CMAKE_BUILD_TYPE=${{ matrix.build }}
+      - run: cmake --build --preset ${{ matrix.preset }}
       - run: tar -czvf build.tar.gz build
         if: ${{ matrix.save }}
 

--- a/.ignore
+++ b/.ignore
@@ -1,2 +1,6 @@
 .git/
 extern/
+*.png
+*.gif
+*.svg
+*.ipynb

--- a/.justfile
+++ b/.justfile
@@ -3,29 +3,24 @@
   just --list --unsorted
 
 # setup build config, defaults to Ninja
-[unix]
 @setup generator='Ninja':
-  cmake --preset unix -G '{{generator}}'
+  cmake --preset {{os_family()}} -G '{{generator}}'
 
 # set build option to value
-[unix]
 @set option value:
-  cmake --preset unix -D {{option}}={{value}}
+  cmake --preset {{os_family()}} -D {{option}}={{value}}
 
 # configure all build options via TUI
-[unix]
 @config:
-  ccmake --preset unix
+  ccmake --preset {{os_family()}}
 
 # build target, defaults to all tools
-[unix]
 @build target='all':
-  cmake --build --preset unix --target {{target}}
+  cmake --build --preset {{os_family()}} --target {{target}}
 
 # build and run all tests
-[unix]
 @test: (build 'tests')
-  ctest --preset unix
+  ctest --preset {{os_family()}}
 
 # remove build and reset
 @clean:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,6 +20,17 @@
 				"OPENQMC_BUILD_TOOLS": "ON",
 				"OPENQMC_BUILD_TESTING": "ON"
 			}
+		},
+		{
+			"name": "windows",
+			"inherits": "base",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug",
+				"CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS": "ON",
+				"CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+				"OPENQMC_BUILD_TOOLS": "ON",
+				"OPENQMC_BUILD_TESTING": "ON"
+			}
 		}
 	],
 	"buildPresets": [
@@ -30,12 +41,22 @@
 		{
 			"name": "unix",
 			"configurePreset": "unix"
+		},
+		{
+			"name": "windows",
+			"configurePreset": "windows"
 		}
 	],
 	"testPresets": [
 		{
 			"name": "unix",
-			"configurePreset": "base",
+			"configurePreset": "unix",
+			"output": {"outputOnFailure": true},
+			"execution": {"noTestsAction": "error", "stopOnFailure": true}
+		},
+		{
+			"name": "windows",
+			"configurePreset": "windows",
 			"output": {"outputOnFailure": true},
 			"execution": {"noTestsAction": "error", "stopOnFailure": true}
 		}

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Supported operating systems:
 
 - Linux
 - macOS
-- Windows (in development)
+- Windows
 
 Supported architectures:
 
@@ -1048,7 +1048,6 @@ Roadmap for version 1.0.0 of the library:
 
 - Gather feedback and iterate.
 - Add complete documentation.
-- Add support for Windows OS.
 - Add more package managers.
 
 ## Developer workflow

--- a/include/oqmc/reverse.h
+++ b/include/oqmc/reverse.h
@@ -33,9 +33,12 @@ OQMC_HOST_DEVICE constexpr std::uint32_t reverseBits32(std::uint32_t value)
 	value = (((value & 0xcccccccc) >> 2) | ((value & 0x33333333) << 2));
 	value = (((value & 0xf0f0f0f0) >> 4) | ((value & 0x0f0f0f0f) << 4));
 
+#if defined(_MSC_VER)
+	value = (((value & 0xff00ff00) >> 8) | ((value & 0x00ff00ff) << 8));
+	value = ((value >> 16) | (value << 16));
+#else
 	value = __builtin_bswap32(value);
-	// value = (((value & 0xff00ff00) >> 8) | ((value & 0x00ff00ff) << 8));
-	// value = ((value >> 16) | (value << 16));
+#endif
 #endif
 
 	return value;
@@ -58,8 +61,11 @@ OQMC_HOST_DEVICE constexpr std::uint16_t reverseBits16(std::uint16_t value)
 	value = (((value & 0xcccccccc) >> 2) | ((value & 0x33333333) << 2));
 	value = (((value & 0xf0f0f0f0) >> 4) | ((value & 0x0f0f0f0f) << 4));
 
+#if defined(_MSC_VER)
+	value = ((value >> 8) | (value << 8));
+#else
 	value = __builtin_bswap16(value);
-	// value = ((value >> 8) | (value << 8));
+#endif
 #endif
 
 	return value;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(tests PRIVATE
 	hypothesis::hypothesis)
 
 target_compile_features(tests PRIVATE cxx_std_14)
+target_compile_definitions(tests PRIVATE _USE_MATH_DEFINES)
 target_compile_definitions(tests PRIVATE OQMC_FORCE_SCALAR)
 
 # Register tests with CTest

--- a/src/tests/hypothesis.h
+++ b/src/tests/hypothesis.h
@@ -153,7 +153,7 @@ void nullHypothesisChiSquareImpl(int numTests, int numSamples,
 
 template <int NumHeavisides, typename Sampler>
 void nullHypothesisTTest(int numSeeds, int numSamples, float significanceLevel,
-                         Sampler sampler)
+                         Sampler& sampler)
 {
 	const auto numTests = numSeeds * (7 + NumHeavisides);
 	const auto heavisides = new OrientedHeaviside[NumHeavisides];
@@ -203,7 +203,7 @@ void nullHypothesisTTest(int numSeeds, int numSamples, float significanceLevel,
 
 template <int Resolution, typename Sampler>
 void nullHypothesisChiSquare(int numSeeds, int numSamples,
-                             float significanceLevel, Sampler sampler)
+                             float significanceLevel, Sampler& sampler)
 {
 	for(int seed = 0; seed < numSeeds; ++seed)
 	{
@@ -216,17 +216,19 @@ void nullHypothesisChiSquare(int numSeeds, int numSamples,
 #define NULL_HYPOTHESIS_TTEST(name, description, functor)                      \
 	TEST(name, tTest##description##Pattern)                                    \
 	{                                                                          \
+		auto sampler = functor;                                                \
 		nullHypothesisTTest<defaultNumHeavisides>(                             \
 		    defaultNumSeeds, defaultNumSamplesHigh, defaultSignificanceLevel,  \
-		    functor);                                                          \
+		    sampler);                                                          \
 	}
 
 #define NULL_HYPOTHESIS_CHISQUARE(name, description, functor)                  \
 	TEST(name, chiSquareTest##description##Pattern)                            \
 	{                                                                          \
+		auto sampler = functor;                                                \
 		nullHypothesisChiSquare<defaultResolution>(                            \
 		    defaultNumSeeds, defaultNumSamplesLow, defaultSignificanceLevel,   \
-		    functor);                                                          \
+		    sampler);                                                          \
 	}
 
 #define ALL_HYPOTHESIS_TESTS(name, description, functor)                       \

--- a/src/tools/lib/CMakeLists.txt
+++ b/src/tools/lib/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(tools PRIVATE ${PROJECT_NAME}
 	glm::glm)
 
 target_compile_features(tools PRIVATE cxx_std_14)
+target_compile_definitions(tools PRIVATE _USE_MATH_DEFINES)
 target_include_directories(tools INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_architecture(tools)

--- a/src/tools/lib/optimise.cpp
+++ b/src/tools/lib/optimise.cpp
@@ -262,7 +262,8 @@ void initialiseEstimates(int nsamples, const void* cache, Array3d pixelFrame,
 		};
 
 		const auto begin = index;
-		const auto end = std::min(index + transactionSize, pixelFrame.size());
+		const auto end =
+		    std::min<int>(index + transactionSize, pixelFrame.size());
 
 		OQMC_FORLOOP(func, begin, end);
 
@@ -294,7 +295,8 @@ void initialiseErrors(int nsamples, const void* cache, Array3d errorFrame,
 		};
 
 		const auto begin = index;
-		const auto end = std::min(index + transactionSize, errorFrame.size());
+		const auto end =
+		    std::min<int>(index + transactionSize, errorFrame.size());
 
 		OQMC_FORLOOP(func, begin, end);
 
@@ -337,7 +339,8 @@ void initialiseErrors(int nsamples, const void* cache, Array3d errorFrame,
 		};
 
 		const auto begin = index;
-		const auto end = std::min(index + transactionSize, errorFrame.size());
+		const auto end =
+		    std::min<int>(index + transactionSize, errorFrame.size());
 
 		OQMC_FORLOOP(func, begin, end);
 
@@ -394,7 +397,8 @@ void initialiseDistances(Array3d pixelFrame, Array3d errorFrame,
 		};
 
 		const auto begin = index;
-		const auto end = std::min(index + transactionSize, graphFrame.size());
+		const auto end =
+		    std::min<long int>(index + transactionSize, graphFrame.size());
 
 		OQMC_FORLOOP(func, begin, end);
 
@@ -449,7 +453,8 @@ void initialiseDistances(Array3d pixelFrame, Array3d errorFrame,
 		};
 
 		const auto begin = index;
-		const auto end = std::min(index + transactionSize, graphFrame.size());
+		const auto end =
+		    std::min<long int>(index + transactionSize, graphFrame.size());
 
 		OQMC_FORLOOP(func, begin, end);
 


### PR DESCRIPTION
There are a few minor changes required to the library itself to make it compatible with MSVC.

Add a new 'windows' preset to the CMakePreset and make the changes for MSVC compatibility. Further, update the CI and other documentation.

This resolves issue #1.

FYI @joesfer.