### PR TITLE
Fix broken link to Framestore website on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 OpenQMC is a library for sampling high quality Quasi-Monte Carlo (QMC) points
 and generating pseudo random numbers. Designed for graphics applications,
-the library is part of Framestore's proprietary renderer [Freak](https://www.framestore.com/work/rendering)
+the library is part of Framestore's proprietary renderer [Freak](https://www.framestore.com/technology/freak)
 and is actively used in VFX production.
 
 <picture>


### PR DESCRIPTION
Since a recent major update to the public Framestore website, all tech pages are now under a different URL.

Update the README page so that the one link back to the Freak technology page on the public site is correct.