### PR TITLE
Format reported coverage percentage

### DIFF
--- a/.github/workflows/coverage-job.yml
+++ b/.github/workflows/coverage-job.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Extract the total function coverage percentage
       - run: sudo apt-get update && sudo apt-get install jq
-      - run: echo "COVERAGE=$(jq '.data[0].totals.functions.percent' coverage.json)" >> $GITHUB_ENV
+      - run: echo "COVERAGE=$(jq '.data[0].totals.functions.percent' coverage.json | xargs printf '%.0f\n')" >> $GITHUB_ENV
 
       # Upload json data for coverage badge
       - uses: schneegans/dynamic-badges-action@v1.7.0


### PR DESCRIPTION
The reported percentage for test coverage had full floating point precision. This is hard to read when output as a badge on the README.

Use 'printf' command to format (remove and digits after the decimal place) the percentage value returned by 'jq'.