### PR TITLE
Add range based integer remapping to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ oqmc::Sampler oqmc::Sampler::newDomainSplit(int key, int size, int index) const;
 
 ```cpp
 /**
- * @brief Draw integer sample values from domain
+ * @brief Draw integer sample values from domain.
  * @details This can compute sample values with up to 4 dimensions for the
  * given domain. The operation does not change the state of the object, and
  * for a single domain and index, the result of this function will always be
@@ -465,7 +465,23 @@ void oqmc::Sampler::drawSample(std::uint32_t sample[Size]) const;
 
 ```cpp
 /**
- * @brief Draw floating point sample values from domain
+ * @brief Draw ranged integer sample values from domain.
+ * @details This function wraps the integer variant of drawSample above. But
+ * transforms the output values into uniformly distributed integers within
+ * the range of [0, range).
+ *
+ * @tparam Size Number of dimensions to draw. Must be within [1, 4].
+ *
+ * @param [out] sample Output array to store sample values.
+ */
+template <int Size>
+OQMC_HOST_DEVICE void drawSample(std::uint32_t range,
+                                 std::uint32_t sample[Size]) const;
+```
+
+```cpp
+/**
+ * @brief Draw floating point sample values from domain.
  * @details This function wraps the integer variant of drawSample above. But
  * transforms the output values into uniformly distributed floats within the
  * range of [0, 1).
@@ -480,7 +496,7 @@ void oqmc::Sampler::drawSample(float sample[Size]) const;
 
 ```cpp
 /**
- * @brief Draw integer pseudo random values from domain
+ * @brief Draw integer pseudo random values from domain.
  * @details This can compute rnd values with up to 4 dimensions for the
  * given domain. The operation does not change the state of the object, and
  * for a single domain and index, the result of this function will always be
@@ -501,7 +517,23 @@ void oqmc::Sampler::drawRnd(std::uint32_t rnd[Size]) const;
 
 ```cpp
 /**
- * @brief Draw floating point pseudo random values from domain
+ * @brief Draw ranged integer pseudo random values from domain.
+ * @details This function wraps the integer variant of drawRnd above. But
+ * transforms the output values into uniformly distributed integers within
+ * the range of [0, range).
+ *
+ * @tparam Size Number of dimensions to draw. Must be within [1, 4].
+ *
+ * @param [out] rnd Output array to store rnd values.
+ */
+template <int Size>
+OQMC_HOST_DEVICE void drawRnd(std::uint32_t range,
+                              std::uint32_t rnd[Size]) const;
+```
+
+```cpp
+/**
+ * @brief Draw floating point pseudo random values from domain.
  * @details This function wraps the integer variant of drawRnd above. But
  * transforms the output values into uniformly distributed floats within the
  * range of [0, 1).

--- a/include/oqmc/pcg.h
+++ b/include/oqmc/pcg.h
@@ -131,66 +131,6 @@ OQMC_HOST_DEVICE constexpr std::uint32_t rng(std::uint32_t& state)
 	return output(state);
 }
 
-/**
- * @brief Compute an unsigned random integer within 0-bounded half-open range.
- * @details Given a range defined using a single unsigned integer, use a PRNG
- * to compute a random integer value within that range. This function will not
- * introduce any statistical bias that is typically present when using more
- * naive methods, such as a modulo operator.
- *
- * From the following paper: https://doi.org/10.48550/arXiv.1805.10941. Note
- * that this algorithm (see Java) reduces the number of expected divisions to
- * almost one. However, low-order bits which can be weak in some PRNGs pass
- * through to the output. PCG has strong low-order bits. For low-discrepency
- * sequences it is recomended to use a multiplcation method instead. This will
- * preserve good properties in the correlation between outputs of the sequence.
- *
- * @param [in] range Exclusive end of integer range. Greater than zero.
- * @param [in, out] state State value of the PRNG. Will be mutated.
- * @return Output PRNG value within integer range.
- *
- * @pre State must have been initialised using an init function.
- */
-OQMC_HOST_DEVICE constexpr std::uint32_t rngBounded(std::uint32_t range,
-                                                    std::uint32_t& state)
-{
-	assert(range > 0);
-
-	auto x = rng(state);
-	auto r = x % range;
-
-	while(x - r > (-range))
-	{
-		x = rng(state);
-		r = x % range;
-	}
-
-	return r;
-}
-
-/**
- * @brief Compute an unsigned random integer within half-open range.
- * @details Given a range defined using two unsigned integers, use a PRNG to
- * compute a random integer value within that range. This function will not
- * introduce any statistical bias that is typically present when using more
- * naive methods, such as a modulo operator.
- *
- * @param [in] begin Inclusive beginning of integer range. Less than end.
- * @param [in] end Exclusive end of integer range. Greater than begin.
- * @param [in, out] state State value of the PRNG. Will be mutated.
- * @return Output PRNG value within integer range.
- *
- * @pre State must have been initialised using an init function.
- */
-OQMC_HOST_DEVICE constexpr std::uint32_t
-rngBounded(std::uint32_t begin, std::uint32_t end, std::uint32_t& state)
-{
-	assert(begin < end);
-
-	const auto range = end - begin;
-	return rngBounded(range, state) + begin;
-}
-
 } // namespace pcg
 
 } // namespace oqmc

--- a/include/oqmc/range.h
+++ b/include/oqmc/range.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenQMC Project.
+
+/**
+ * @file
+ * @details Functionality for remapping integer values to within a bounded range
+ * while retaining quality properties of random numbers at low cost.
+ */
+
+#pragma once
+
+#include "gpu.h"
+
+#include <cassert>
+#include <cstdint>
+
+namespace oqmc
+{
+
+/**
+ * @brief Compute an unsigned integer within 0-bounded half-open range.
+ * @details Given a range defined using a single unsigned integer, map a full
+ * range 32 bit unsigned integer into range.
+ *
+ * This function will avoid any division using a multiplication method that
+ * preserves the high order bits. This means that PRNGs with weak low order
+ * bits, as welll as QMC sequences, will both retain their good properties.
+ *
+ * Due to these reasons, this function should be prefered over other naive
+ * methods such as a modulo operator. It does however still introduce a form of
+ * bias at large non power-of-two ranges. This could be resolved with a simple
+ * extension ivolving a rejection method. However such methods do not integrate
+ * well with the larger design, and so are not used as a practical compromise.
+ *
+ * For further information see Section 4 in https://arxiv.org/abs/1805.10941 as
+ * well as https://www.pcg-random.org/posts/bounded-rands.html from PCG.
+ *
+ * @param [in] value Full ranged 32 bit unsigned integer.
+ * @param [in] range Exclusive end of integer range. Greater than zero.
+ * @return Output value remapped within integer range.
+ */
+OQMC_HOST_DEVICE constexpr std::uint32_t uintToRange(std::uint32_t value,
+                                                     std::uint32_t range)
+{
+	assert(range > 0);
+
+	// Modern compilers will optimise this down to a standard mult instruction,
+	// avoiding 64 bits, taking only the upper order bits in the EAX register.
+	const auto x = static_cast<std::uint64_t>(value);
+	const auto y = static_cast<std::uint64_t>(range);
+	return x * y >> 32;
+}
+
+/**
+ * @brief Compute an unsigned integer within half-open range.
+ * @details Given a range defined using two unsigned integers, map a full range
+ * 32 bit unsigned integer into range. This function is based upon the other
+ * uint to range function and has the same properties.
+ *
+ * @param [in] value Full ranged 32 bit unsigned integer.
+ * @param [in] begin Inclusive beginning of integer range. Less than end.
+ * @param [in] end Exclusive end of integer range. Greater than begin.
+ * @return Output value remapped within integer range.
+ */
+OQMC_HOST_DEVICE constexpr std::uint32_t
+uintToRange(std::uint32_t value, std::uint32_t begin, std::uint32_t end)
+{
+	assert(begin < end);
+
+	return uintToRange(value, end - begin) + begin;
+}
+
+} // namespace oqmc

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(tests EXCLUDE_FROM_ALL
 	pmj.cpp
 	pmjbn.cpp
 	permute.cpp
+	range.cpp
 	rank1.cpp
 	reverse.cpp
 	rotate.cpp

--- a/src/tests/pcg.cpp
+++ b/src/tests/pcg.cpp
@@ -47,35 +47,8 @@ struct SamplerV2
 	std::uint32_t hash;
 };
 
-struct SamplerV3
-{
-	void initialise(int seed)
-	{
-		state = oqmc::pcg::init(seed);
-	}
-
-	void sample(int index, std::uint32_t out[2])
-	{
-		OQMC_MAYBE_UNUSED(index);
-
-		// Does not divide into UINT32_MAX to test debiasing.
-		constexpr auto range = UINT32_MAX / 4 * 3;
-		constexpr auto scalar = UINT64_MAX / range;
-
-		std::uint32_t rnd[2];
-		rnd[0] = oqmc::pcg::rngBounded(range, state);
-		rnd[1] = oqmc::pcg::rngBounded(range, state);
-
-		out[0] = std::uint32_t(std::uint64_t(rnd[0]) * scalar >> 32);
-		out[1] = std::uint32_t(std::uint64_t(rnd[1]) * scalar >> 32);
-	}
-
-	std::uint32_t state;
-};
-
 ALL_HYPOTHESIS_TESTS(PcgTest, Sequential, (SamplerV1()))
 ALL_HYPOTHESIS_TESTS(PcgTest, Parallel, (SamplerV2()))
-ALL_HYPOTHESIS_TESTS(PcgTest, Bounded, (SamplerV3()))
 
 constexpr std::array<std::uint32_t, 20> primes{
     2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
@@ -179,82 +152,6 @@ TEST(PcgTest, HashRngEqual)
 		const auto rnd = oqmc::pcg::rng(state);
 
 		EXPECT_EQ(hash, rnd);
-	}
-}
-
-TEST(PcgTest, BoundedRange)
-{
-	for(auto range : primes)
-	{
-		auto state = oqmc::pcg::init();
-
-		for(int i = 0; i < 128; ++i)
-		{
-			const auto rnd = oqmc::pcg::rngBounded(range, state);
-
-			EXPECT_LT(rnd, range);
-		}
-	}
-
-	for(auto range : powers)
-	{
-		auto state = oqmc::pcg::init();
-
-		for(int i = 0; i < 128; ++i)
-		{
-			const auto rnd = oqmc::pcg::rngBounded(range, state);
-
-			EXPECT_LT(rnd, range);
-		}
-	}
-}
-
-TEST(PcgTest, BoundedBeginEnd)
-{
-	for(auto range : primes)
-	{
-		auto state = oqmc::pcg::init();
-
-		for(int i = 0; i < 128; ++i)
-		{
-			auto stateA = state;
-			auto stateB = state;
-
-			const auto begin = range;
-			const auto end = range * 2;
-
-			const auto rndA = oqmc::pcg::rngBounded(begin, end, stateA);
-			const auto rndB = oqmc::pcg::rngBounded(range, stateB);
-
-			EXPECT_GE(rndA, begin);
-			EXPECT_LT(rndA, end);
-			EXPECT_EQ(rndA - begin, rndB);
-
-			state = stateA;
-		}
-	}
-
-	for(auto range : powers)
-	{
-		auto state = oqmc::pcg::init();
-
-		for(int i = 0; i < 128; ++i)
-		{
-			auto stateA = state;
-			auto stateB = state;
-
-			const auto begin = range;
-			const auto end = range * 2;
-
-			const auto rndA = oqmc::pcg::rngBounded(begin, end, stateA);
-			const auto rndB = oqmc::pcg::rngBounded(range, stateB);
-
-			EXPECT_GE(rndA, begin);
-			EXPECT_LT(rndA, end);
-			EXPECT_EQ(rndA - begin, rndB);
-
-			state = stateA;
-		}
 	}
 }
 

--- a/src/tests/range.cpp
+++ b/src/tests/range.cpp
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenQMC Project.
+
+#include "hypothesis.h"
+#include <oqmc/pcg.h>
+#include <oqmc/range.h>
+#include <oqmc/unused.h>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+namespace
+{
+
+struct SamplerV1
+{
+	void initialise(int seed)
+	{
+		state = oqmc::pcg::init(seed);
+	}
+
+	void sample(int index, std::uint32_t out[2])
+	{
+		OQMC_MAYBE_UNUSED(index);
+
+		// Does not divide into UINT32_MAX to test debiasing.
+		constexpr auto range = UINT32_MAX / 4 * 3;
+		constexpr auto scalar = UINT64_MAX / range;
+
+		std::uint32_t rnd[2];
+		rnd[0] = oqmc::uintToRange(oqmc::pcg::rng(state), range);
+		rnd[1] = oqmc::uintToRange(oqmc::pcg::rng(state), range);
+
+		out[0] = std::uint32_t(std::uint64_t(rnd[0]) * scalar >> 32);
+		out[1] = std::uint32_t(std::uint64_t(rnd[1]) * scalar >> 32);
+	}
+
+	std::uint32_t state;
+};
+
+ALL_HYPOTHESIS_TESTS(RangeTest, Debiased, (SamplerV1()))
+
+constexpr std::array<std::uint32_t, 20> primes{
+    2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+};
+
+constexpr std::array<std::uint32_t, 10> powers{
+    1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
+};
+
+TEST(RangeTest, BoundedRange)
+{
+	for(auto range : primes)
+	{
+		auto state = oqmc::pcg::init();
+
+		for(int i = 0; i < 128; ++i)
+		{
+			const auto rnd = oqmc::uintToRange(oqmc::pcg::rng(state), range);
+
+			EXPECT_LT(rnd, range);
+		}
+	}
+
+	for(auto range : powers)
+	{
+		auto state = oqmc::pcg::init();
+
+		for(int i = 0; i < 128; ++i)
+		{
+			const auto rnd = oqmc::uintToRange(oqmc::pcg::rng(state), range);
+
+			EXPECT_LT(rnd, range);
+		}
+	}
+}
+
+TEST(RangeTest, BoundedBeginEnd)
+{
+	for(auto range : primes)
+	{
+		auto state = oqmc::pcg::init();
+
+		for(int i = 0; i < 128; ++i)
+		{
+			auto stateA = state;
+			auto stateB = state;
+
+			const auto begin = range;
+			const auto end = range * 2;
+
+			const auto rndA =
+			    oqmc::uintToRange(oqmc::pcg::rng(stateA), begin, end);
+			const auto rndB = oqmc::uintToRange(oqmc::pcg::rng(stateB), range);
+
+			EXPECT_GE(rndA, begin);
+			EXPECT_LT(rndA, end);
+			EXPECT_EQ(rndA - begin, rndB);
+
+			state = stateA;
+		}
+	}
+
+	for(auto range : powers)
+	{
+		auto state = oqmc::pcg::init();
+
+		for(int i = 0; i < 128; ++i)
+		{
+			auto stateA = state;
+			auto stateB = state;
+
+			const auto begin = range;
+			const auto end = range * 2;
+
+			const auto rndA =
+			    oqmc::uintToRange(oqmc::pcg::rng(stateA), begin, end);
+			const auto rndB = oqmc::uintToRange(oqmc::pcg::rng(stateB), range);
+
+			EXPECT_GE(rndA, begin);
+			EXPECT_LT(rndA, end);
+			EXPECT_EQ(rndA - begin, rndB);
+
+			state = stateA;
+		}
+	}
+}
+
+} // namespace

--- a/src/tools/lib/optimise.cpp
+++ b/src/tools/lib/optimise.cpp
@@ -14,6 +14,7 @@
 #include <oqmc/lookup.h>
 #include <oqmc/owen.h>
 #include <oqmc/pcg.h>
+#include <oqmc/range.h>
 #include <oqmc/rank1.h>
 #include <oqmc/state.h>
 #include <oqmc/stochastic.h>
@@ -199,7 +200,8 @@ void initialisePermutations(int& seed, Array3d pixelFrame, int* permutations)
 	for(int i = 0; i < pixelFrame.size(); ++i)
 	{
 		swap(permutations[i],
-		     permutations[oqmc::pcg::rngBounded(i, pixelFrame.size(), state)]);
+		     permutations[oqmc::uintToRange(oqmc::pcg::rng(state), i,
+		                                    pixelFrame.size())]);
 	}
 }
 


### PR DESCRIPTION
Sampler interfaces do not provide a method to integer remap values from either the QMC sequence or a PRNG to an integer range. It would be beneficial to provide dedicated support for such remapping as the implementation can be nuanced as well as have considerable performance pitfalls.

Add support on the SamplerInterface to produce both PRNG values and QMC samples within a ranged interval. Remove redundant functionality from the pcg.h file and unit tests. Add a new dedicated rnage.h file.