### PR TITLE
Add missing API reference docs for range parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ void oqmc::Sampler::drawSample(std::uint32_t sample[Size]) const;
  *
  * @tparam Size Number of dimensions to draw. Must be within [1, 4].
  *
+ * @param [in] range Exclusive end of range. Greater than zero.
  * @param [out] sample Output array to store sample values.
  */
 template <int Size>
@@ -523,6 +524,7 @@ void oqmc::Sampler::drawRnd(std::uint32_t rnd[Size]) const;
  *
  * @tparam Size Number of dimensions to draw. Must be within [1, 4].
  *
+ * @param [in] range Exclusive end of range. Greater than zero.
  * @param [out] rnd Output array to store rnd values.
  */
 template <int Size>

--- a/include/oqmc/sampler.h
+++ b/include/oqmc/sampler.h
@@ -240,6 +240,7 @@ class SamplerInterface
 	 *
 	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
 	 *
+	 * @param [in] range Exclusive end of range. Greater than zero.
 	 * @param [out] sample Output array to store sample values.
 	 */
 	template <int Size>
@@ -286,6 +287,7 @@ class SamplerInterface
 	 *
 	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
 	 *
+	 * @param [in] range Exclusive end of range. Greater than zero.
 	 * @param [out] rnd Output array to store rnd values.
 	 */
 	template <int Size>


### PR DESCRIPTION
Documentation for the new range parameter on the SamplerInterface was missing with both the drawSample and the drawRnd function definitions.

Add doxygen documentation for both functions, in both the interface definition and the README file.