### PR TITLE
Update documentation on handling sampler state

### DIFF
--- a/include/oqmc/lattice.h
+++ b/include/oqmc/lattice.h
@@ -20,11 +20,7 @@
 namespace oqmc
 {
 
-/**
- * @brief Lattice sampler implemention without public interface.
- * @details Private implementation details of the lattice sampler. Use the
- * aliased LatticeSampler type to access the sampler via the SamplerInterface.
- */
+/// @cond
 class LatticeImpl
 {
 	// See SamplerInterface for public API documentation.
@@ -96,6 +92,7 @@ void LatticeImpl::drawRnd(std::uint32_t rnd[Size]) const
 {
 	state.drawRnd<Size>(rnd);
 }
+/// @endcond
 
 /**
  * @brief Rank one lattice sampler.

--- a/include/oqmc/latticebn.h
+++ b/include/oqmc/latticebn.h
@@ -23,12 +23,7 @@
 namespace oqmc
 {
 
-/**
- * @brief Lattice blue noise sampler implementation without public interface.
- * @details Private implementation details of the lattice blue noise sampler.
- * Use the aliased LatticeBnSampler type to access the sampler via the
- * SamplerInterface.
- */
+/// @cond
 class LatticeBnImpl
 {
 	// See SamplerInterface for public API documentation.
@@ -131,6 +126,7 @@ void LatticeBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 {
 	state.newDomain(state.pixelId).drawRnd<Size>(rnd);
 }
+/// @endcond
 
 /**
  * @brief Blue noise variant of lattice sampler.

--- a/include/oqmc/pmj.h
+++ b/include/oqmc/pmj.h
@@ -20,11 +20,7 @@
 namespace oqmc
 {
 
-/**
- * @brief Pmj sampler implementation without public interface.
- * @details Private implementation details of the pmj sampler. Use the aliased
- * PmjSampler type to access the sampler via the SamplerInterface.
- */
+/// @cond
 class PmjImpl
 {
 	// See SamplerInterface for public API documentation.
@@ -107,6 +103,7 @@ void PmjImpl::drawRnd(std::uint32_t rnd[Size]) const
 {
 	state.drawRnd<Size>(rnd);
 }
+/// @endcond
 
 /**
  * @brief Low discrepancy pmj sampler.

--- a/include/oqmc/pmjbn.h
+++ b/include/oqmc/pmjbn.h
@@ -24,11 +24,7 @@
 namespace oqmc
 {
 
-/**
- * @brief Pmj blue noise sampler implementation without public interface.
- * @details Private implementation details of the pmj blue noise sampler. Use
- * the aliased PmjBnSampler type to access the sampler via the SamplerInterface.
- */
+/// @cond
 class PmjBnImpl
 {
 	// See SamplerInterface for public API documentation.
@@ -133,6 +129,7 @@ void PmjBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 {
 	state.newDomain(state.pixelId).drawRnd<Size>(rnd);
 }
+/// @endcond
 
 /**
  * @brief Blue noise variant of pmj sampler.

--- a/include/oqmc/sobol.h
+++ b/include/oqmc/sobol.h
@@ -20,11 +20,7 @@
 namespace oqmc
 {
 
-/**
- * @brief Sobol sampler implementation without public interface.
- * @details Private implementation details of the sobol sampler. Use the aliased
- * SobolSampler type to access the sampler via the SamplerInterface.
- */
+/// @cond
 class SobolImpl
 {
 	// See SamplerInterface for public API documentation.
@@ -96,6 +92,7 @@ void SobolImpl::drawRnd(std::uint32_t rnd[Size]) const
 {
 	state.drawRnd<Size>(rnd);
 }
+/// @endcond
 
 /**
  * @brief Owen scrambled sobol sampler.

--- a/include/oqmc/sobolbn.h
+++ b/include/oqmc/sobolbn.h
@@ -23,12 +23,7 @@
 namespace oqmc
 {
 
-/**
- * @brief Sobol blue noise sampler implementation without public interface.
- * @details Private implementation details of the sobol blue noise sampler.
- * Use the aliased SobolBnSampler type to access the sampler via the
- * SamplerInterface.
- */
+/// @cond
 class SobolBnImpl
 {
 	// See SamplerInterface for public API documentation.
@@ -131,6 +126,7 @@ void SobolBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 {
 	state.newDomain(state.pixelId).drawRnd<Size>(rnd);
 }
+/// @endcond
 
 /**
  * @brief Blue noise variant of sobol sampler.


### PR DESCRIPTION
The documentation is perhaps too technical and does not give clear enough guidance on sampler state and how it should be managed.

Update and match the documentation in both the README page as-well-as in the source code for Doxygen output. Give clear guidance on how to pack samplers when deferring computation to a queue, or passing a sampler to a function. Remove the sampler implementations from the docs.