### PR TITLE
Update the action versions in all GH workflows

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pip install ruff==0.1.6
       - run: scripts/check-format.sh
 
@@ -19,7 +19,7 @@ jobs:
     name: Check static analysis
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pip install ruff==0.1.6
       - run: cmake --preset unix
       - run: scripts/check-lint.sh
@@ -28,7 +28,7 @@ jobs:
     name: Check documentation
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt-get update && sudo apt-get install doxygen graphviz
       - run: scripts/check-documentation.sh
 
@@ -40,12 +40,12 @@ jobs:
       - check-documentation
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cmake --preset base -D CMAKE_INSTALL_PREFIX=install
       - run: cmake --build --preset base --target install
 
       # Upload installation for example-config
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with: {name: install, path: "install"}
 
   example-config:
@@ -53,10 +53,10 @@ jobs:
     needs: install
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Download installation
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with: {name: install, path: "install"}
 
       - run: cmake -S cmake/examples/config -B build -D CMAKE_INSTALL_PREFIX=install
@@ -68,7 +68,7 @@ jobs:
     needs: install
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cmake -S cmake/examples/submodule -B build
       - run: cmake --build build
       - run: ./build/example-submodule
@@ -78,7 +78,7 @@ jobs:
     needs: install
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cmake -S cmake/examples/include -B build
       - run: cmake --build build
       - run: ./build/example-include
@@ -94,7 +94,7 @@ jobs:
         build: [Release, Debug]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cmake --preset unix -D CMAKE_BUILD_TYPE=${{ matrix.build }}
       - run: cmake --build --preset unix --target tests
       - run: ctest --preset unix
@@ -125,14 +125,14 @@ jobs:
           - {os: self-hosted, preset: unix, save: true}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cmake --preset ${{ matrix.preset }} -D OPENQMC_ARCH_TYPE=${{ matrix.arch }} -D CMAKE_BUILD_TYPE=${{ matrix.build }}
       - run: cmake --build --preset ${{ matrix.preset }}
       - run: tar -czvf build.tar.gz build
         if: ${{ matrix.save }}
 
       # Upload tools build for test-generate
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with: {name: "${{ matrix.build }}-${{ matrix.arch }}", path: build.tar.gz}
         if: ${{ matrix.save }}
 
@@ -145,14 +145,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       # Download tools build
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with: {name: Release-Scalar}
 
       - run: tar -xzvf build.tar.gz
       - run: ./build/src/tools/cli/generate ${{ matrix.sampler }} > data
 
       # Upload sample data for test-generate
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with: {name: "${{ matrix.sampler }}", path: data}
 
   test-generate:
@@ -173,11 +173,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # Download tools build
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with: {name: "${{ matrix.build }}-${{ matrix.arch }}"}
 
       # Download sample data
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with: {name: "${{ matrix.sampler }}"}
 
       - run: tar -xzvf build.tar.gz

--- a/.github/workflows/coverage-job.yml
+++ b/.github/workflows/coverage-job.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test coverage
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Install and set LLVM and Clang respectively
       - run: sudo apt-get update && sudo apt-get install llvm
@@ -42,5 +42,5 @@ jobs:
           maxColorRange: 100
 
       # Upload coverage report artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with: {name: coverage-report, path: "coverage-report"}

--- a/.github/workflows/documentation-job.yml
+++ b/.github/workflows/documentation-job.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Install doxygen and graphviz
       - run: sudo apt-get update && sudo apt-get install doxygen graphviz
@@ -18,5 +18,5 @@ jobs:
       - run: doxygen
 
       # Upload api documentation artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with: {name: api-documentation, path: "html"}


### PR DESCRIPTION
There are warning about the deprecation of the current GitHub actions used in the CI and other workflows. This is to do with them switching from Node 16 to Node 20.

Update the versions of all major actions from v3 to v4 across all the workflow files.