### PR TITLE
Update the formatting used for Doxygen comments

### DIFF
--- a/include/oqmc/arch.h
+++ b/include/oqmc/arch.h
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Defines what architecture to target. This is based on what features
- * are enabled by the compiler using the build options.
- */
+/// @file
+/// @details Defines what architecture to target. This is based on what features
+/// are enabled by the compiler using the build options.
 
 #pragma once
 

--- a/include/oqmc/bntables.h
+++ b/include/oqmc/bntables.h
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Pre-computed and optimised blue noise tables used to decorrelate
- * between pixels, and extend the base sampler implementations with blue noise
- * properties. A generalised method extending 'Lessons Learned and Improvements
- * when Building Screen-Space Samplers with Blue-Noise Error Distribution.'
- * by Laurent Belcour and Eric Heitz was used to optimise the tables. Lookups
- * for the table can apply constant random shifts for different domains,
- * allowing a single table to be re-used for N domains.
- */
+/// @file
+/// @details Pre-computed and optimised blue noise tables used to decorrelate
+/// between pixels, and extend the base sampler implementations with blue noise
+/// properties. A generalised method extending 'Lessons Learned and Improvements
+/// when Building Screen-Space Samplers with Blue-Noise Error Distribution.'
+/// by Laurent Belcour and Eric Heitz was used to optimise the tables. Lookups
+/// for the table can apply constant random shifts for different domains,
+/// allowing a single table to be re-used for N domains.
 
 #pragma once
 
@@ -25,33 +23,28 @@ namespace oqmc
 namespace bntables
 {
 
-/**
- * @brief Return type for table value.
- * @details This type composes both a key and a rank value as a pair. These
- * values can then be used to randomise a sequence.
- */
+/// Return type for table value.
+/// This type composes both a key and a rank value as a pair. These values can
+/// then be used to randomise a sequence.
 struct TableReturnValue
 {
 	std::uint32_t key;  ///< key value to randomise.
 	std::uint32_t rank; ///< rank value to shuffle.
 };
 
-/**
- * @brief Lookup value pair from table.
- * @details Given an encoded pixel coordinate and an encoded pixel shift,
- * decode the values and add the shift to the coordinate to compute an index.
- * Using the index lookup a key and rank value pair from the input tables.
- *
- * @tparam XBits Precision along the X axis used for encoding.
- * @tparam YBits Precision along the Y axis used for encoding.
- * @tparam ZBits Precision along the Z axis used for encoding.
- *
- * @param [in] pixel Encoded pixel coordinate for lookup.
- * @param [in] shift Encoded pixel shift for lookup.
- * @param [in] keyTable Table of key values.
- * @param [in] rankTable Table of rank values.
- * @return Key and rank pair from lookup.
- */
+/// Lookup value pair from table.
+/// Given an encoded pixel coordinate and an encoded pixel shift, decode the
+/// values and add the shift to the coordinate to compute an index. Using the
+/// index lookup a key and rank value pair from the input tables.
+///
+/// @tparam XBits Precision along the X axis used for encoding.
+/// @tparam YBits Precision along the Y axis used for encoding.
+/// @tparam ZBits Precision along the Z axis used for encoding.
+/// @param [in] pixel Encoded pixel coordinate for lookup.
+/// @param [in] shift Encoded pixel shift for lookup.
+/// @param [in] keyTable Table of key values.
+/// @param [in] rankTable Table of rank values.
+/// @return Key and rank pair from lookup.
 template <int XBits, int YBits, int ZBits>
 OQMC_HOST_DEVICE constexpr TableReturnValue
 tableValue(std::uint16_t pixel, std::uint16_t shift,
@@ -84,28 +77,20 @@ namespace pmj
 
 #if defined(OQMC_ENABLE_BINARY)
 
-/**
- * @brief Optimised blue noise key table for pmj.
- */
+/// Optimised blue noise key table for pmj.
 extern const std::uint32_t keyTable[size];
 
-/**
- * @brief Optimised blue noise rank table for pmj.
- */
+/// Optimised blue noise rank table for pmj.
 extern const std::uint32_t rankTable[size];
 
 #else
 
-/**
- * @brief Optimised blue noise key table for pmj.
- */
+/// Optimised blue noise key table for pmj.
 constexpr std::uint32_t keyTable[] = {
 #include "data/pmj/keys.txt"
 };
 
-/**
- * @brief Optimised blue noise rank table for pmj.
- */
+/// Optimised blue noise rank table for pmj.
 constexpr std::uint32_t rankTable[] = {
 #include "data/pmj/ranks.txt"
 };
@@ -119,28 +104,20 @@ namespace sobol
 
 #if defined(OQMC_ENABLE_BINARY)
 
-/**
- * @brief Optimised blue noise key table for sobol.
- */
+/// Optimised blue noise key table for sobol.
 extern const std::uint32_t keyTable[size];
 
-/**
- * @brief Optimised blue noise rank table for sobol.
- */
+/// Optimised blue noise rank table for sobol.
 extern const std::uint32_t rankTable[size];
 
 #else
 
-/**
- * @brief Optimised blue noise key table for sobol.
- */
+/// Optimised blue noise key table for sobol.
 constexpr std::uint32_t keyTable[] = {
 #include "data/sobol/keys.txt"
 };
 
-/**
- * @brief Optimised blue noise rank table for sobol.
- */
+/// Optimised blue noise rank table for sobol.
 constexpr std::uint32_t rankTable[] = {
 #include "data/sobol/ranks.txt"
 };
@@ -154,28 +131,20 @@ namespace lattice
 
 #if defined(OQMC_ENABLE_BINARY)
 
-/**
- * @brief Optimised blue noise key table for lattice.
- */
+/// Optimised blue noise key table for lattice.
 extern const std::uint32_t keyTable[size];
 
-/**
- * @brief Optimised blue noise rank table for lattice.
- */
+/// Optimised blue noise rank table for lattice.
 extern const std::uint32_t rankTable[size];
 
 #else
 
-/**
- * @brief Optimised blue noise key table for lattice.
- */
+/// Optimised blue noise key table for lattice.
 constexpr std::uint32_t keyTable[] = {
 #include "data/lattice/keys.txt"
 };
 
-/**
- * @brief Optimised blue noise rank table for lattice.
- */
+/// Optimised blue noise rank table for lattice.
 constexpr std::uint32_t rankTable[] = {
 #include "data/lattice/ranks.txt"
 };

--- a/include/oqmc/encode.h
+++ b/include/oqmc/encode.h
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Functions to encode (compress) and decode (decompress) key data
- * into a smaller memory footprint. This can be used to efficiently store pixel
- * coordinate information.
- */
+/// @file
+/// @details Functions to encode (compress) and decode (decompress) key data
+/// into a smaller memory footprint. This can be used to efficiently store pixel
+/// coordinate information.
 
 #pragma once
 
@@ -17,11 +15,9 @@
 namespace oqmc
 {
 
-/**
- * @brief Key to encode pixel coordinates.
- * @details This structure stores integer coordinate information for each
- * axis of a 3 dimensional array.
- */
+/// Key to encode pixel coordinates.
+/// This structure stores integer coordinate information for each axis of a 3
+/// dimensional array.
 struct EncodeKey
 {
 	int x; ///< x axis coordinate.
@@ -29,20 +25,17 @@ struct EncodeKey
 	int z; ///< z axis coordinate.
 };
 
-/**
- * @brief Encode a key value into 16 bits.
- * @details Given a coordinate key and a given precision for each axis,
- * encode the values into a single 16 bit integer value. This can be a lossy
- * operation. The sum of all precisions must be equal to or less than 16 bits.
- * Decode the values using the decodeBits16 function.
- *
- * @tparam XBits Requested precision along the X axis.
- * @tparam YBits Requested precision along the Y axis.
- * @tparam ZBits Requested precision along the Z axis.
- *
- * @param [in] key Key of coordinates to encode.
- * @return Encoded 16 bit integer.
- */
+/// Encode a key value into 16 bits.
+/// Given a coordinate key and a given precision for each axis, encode the
+/// values into a single 16 bit integer value. This can be a lossy operation.
+/// The sum of all precisions must be equal to or less than 16 bits. Decode the
+/// values using the decodeBits16 function.
+///
+/// @tparam XBits Requested precision along the X axis.
+/// @tparam YBits Requested precision along the Y axis.
+/// @tparam ZBits Requested precision along the Z axis.
+/// @param [in] key Key of coordinates to encode.
+/// @return Encoded 16 bit integer.
 template <int XBits, int YBits, int ZBits>
 OQMC_HOST_DEVICE inline std::uint16_t encodeBits16(EncodeKey key)
 {
@@ -66,20 +59,17 @@ OQMC_HOST_DEVICE inline std::uint16_t encodeBits16(EncodeKey key)
 	return value;
 }
 
-/**
- * @brief Decode a key value back into a key.
- * @details Given a encoded 16 bit integer value and a given precision for each
- * axis, decode the values into a coordinate key. This can be a lossy operation.
- * The sum of all precisions must be equal to or less than 16 bits. Encode the
- * values using the encodeBits16 function.
- *
- * @tparam XBits Requested precision along the X axis.
- * @tparam YBits Requested precision along the Y axis.
- * @tparam ZBits Requested precision along the Z axis.
- *
- * @param [in] value Encoded 16 bit integer.
- * @return Key of encoded coordinates.
- */
+/// Decode a key value back into a key.
+/// Given a encoded 16 bit integer value and a given precision for each axis,
+/// decode the values into a coordinate key. This can be a lossy operation. The
+/// sum of all precisions must be equal to or less than 16 bits. Encode the
+/// values using the encodeBits16 function.
+///
+/// @tparam XBits Requested precision along the X axis.
+/// @tparam YBits Requested precision along the Y axis.
+/// @tparam ZBits Requested precision along the Z axis.
+/// @param [in] value Encoded 16 bit integer.
+/// @return Key of encoded coordinates.
 template <int XBits, int YBits, int ZBits>
 OQMC_HOST_DEVICE inline EncodeKey decodeBits16(std::uint16_t value)
 {

--- a/include/oqmc/float.h
+++ b/include/oqmc/float.h
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Functionality around floating point operations, such as conversion
- * from integer to floating point representation.
- */
+/// @file
+/// @details Functionality around floating point operations, such as conversion
+/// from integer to floating point representation.
 
 #pragma once
 
@@ -20,15 +18,13 @@ namespace oqmc
 constexpr auto floatOneOverUintMax = 2.3283064365386962890625e-10f; ///< 0x1p-32
 constexpr auto floatOneMinusEpsilon = 0.999999940395355224609375f;  ///< max flt
 
-/**
- * @brief Convert an integer into a [0, 1) float.
- * @details Given any representable 32 bit unsigned integer, scale the value
- * into a [0, 1) floating point representation. Note that this operation is
- * lossy and may not be reversible.
- *
- * @param [in] value Input integer value within the range [0, 2^32).
- * @return Floating point number within the range [0, 1).
- */
+/// Convert an integer into a [0, 1) float.
+/// Given any representable 32 bit unsigned integer, scale the value into a [0,
+/// 1) floating point representation. Note that this operation is lossy and may
+/// not be reversible.
+///
+/// @param [in] value Input integer value within the range [0, 2^32).
+/// @return Floating point number within the range [0, 1).
 OQMC_HOST_DEVICE inline float uintToFloat(std::uint32_t value)
 {
 	// This method is inspired by the method used by Matt Pharr in PBRT v4. It

--- a/include/oqmc/gpu.h
+++ b/include/oqmc/gpu.h
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Defines function specifiers which allows the author to inform the
- * compiler a function should be callable on the GPU.
- */
+/// @file
+/// @details Defines function specifiers which allows the author to inform the
+/// compiler a function should be callable on the GPU.
 
 #pragma once
 

--- a/include/oqmc/lattice.h
+++ b/include/oqmc/lattice.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Lattice sampler implementation.
- */
+/// @file
+/// @details Lattice sampler implementation.
 
 #pragma once
 
@@ -94,21 +92,19 @@ void LatticeImpl::drawRnd(std::uint32_t rnd[Size]) const
 }
 /// @endcond
 
-/**
- * @brief Rank one lattice sampler.
- * @details The implementation uses the generator vector from Hickernell et
- * al. in 'Weighted compound integration rules with higher order convergence
- * for all N' to construct a 4D lattice. This is then made into a progressive
- * sequence using a scalar based on a radical inversion of the sample index.
- * Randomisation uses toroidal shifts.
- *
- * This sampler has no cache initialisation cost, it generates all samples on
- * the fly without touching memory. Runtime performance is also high with a
- * relatively low computation cost for a single draw sample call. However the
- * rate of integration per pixel can be lower when compared to other samplers.
- *
- * @ingroup samplers
- */
+/// Rank one lattice sampler.
+/// The implementation uses the generator vector from Hickernell et al. in
+/// 'Weighted compound integration rules with higher order convergence for all
+/// N' to construct a 4D lattice. This is then made into a progressive sequence
+/// using a scalar based on a radical inversion of the sample index.
+/// Randomisation uses toroidal shifts.
+///
+/// This sampler has no cache initialisation cost, it generates all samples on
+/// the fly without touching memory. Runtime performance is also high with a
+/// relatively low computation cost for a single draw sample call. However the
+/// rate of integration per pixel can be lower when compared to other samplers.
+///
+/// @ingroup samplers
 using LatticeSampler = SamplerInterface<LatticeImpl>;
 
 } // namespace oqmc

--- a/include/oqmc/latticebn.h
+++ b/include/oqmc/latticebn.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Latticebn sampler implementation.
- */
+/// @file
+/// @details Latticebn sampler implementation.
 
 #pragma once
 
@@ -128,13 +126,11 @@ void LatticeBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 }
 /// @endcond
 
-/**
- * @brief Blue noise variant of lattice sampler.
- * @details Same as oqmc::LatticeSampler, with additional spatial temporal blue
- * noise dithering between pixels, with progressive pixel sampling support.
- *
- * @ingroup samplers
- */
+/// Blue noise variant of lattice sampler.
+/// Same as oqmc::LatticeSampler, with additional spatial temporal blue noise
+/// dithering between pixels, with progressive pixel sampling support.
+///
+/// @ingroup samplers
 using LatticeBnSampler = SamplerInterface<LatticeBnImpl>;
 
 } // namespace oqmc

--- a/include/oqmc/lookup.h
+++ b/include/oqmc/lookup.h
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Table lookup functionality. This can be paired with various pre-
- * initialised sample sequence methods to randomise a sequence lookup. As a
- * result a single initialised table can be reused to save on initialisation and
- * storage costs.
- */
+/// @file
+/// @details Table lookup functionality. This can be paired with various
+/// pre-initialised sample sequence methods to randomise a sequence lookup. As a
+/// result a single initialised table can be reused to save on initialisation
+/// and storage costs.
 
 #pragma once
 
@@ -21,42 +19,36 @@
 namespace oqmc
 {
 
-/**
- * @brief Random digit scramble an element in a sequence.
- * @details Given a value and a random number, efficiently randomise the value
- * using the random digit scramble method from Kollig and Keller in 'Efficient
- * Multidimensional Sampling'. The implementation just requires a single XOR
- * operation, which although fast will not remove any pre-existing structure
- * present in a sequence. The seed input must be constant for a given sequence.
- *
- * @param [in] value Sequence element.
- * @param [in] hash Random number.
- * @return Randomised element.
- */
+/// Random digit scramble an element in a sequence.
+/// Given a value and a random number, efficiently randomise the value using the
+/// random digit scramble method from Kollig and Keller in 'Efficient
+/// Multidimensional Sampling'. The implementation just requires a single XOR
+/// operation, which although fast will not remove any pre-existing structure
+/// present in a sequence. The seed input must be constant for a given sequence.
+///
+/// @param [in] value Sequence element.
+/// @param [in] hash Random number.
+/// @return Randomised element.
 OQMC_HOST_DEVICE constexpr std::uint32_t
 randomDigitScramble(std::uint32_t value, std::uint32_t hash)
 {
 	return value ^ hash;
 }
 
-/**
- * @brief Compute a randomised value from a pre-computed table.
- * @details Given an index and a seed, compute an scrambled sequence value.
- * The index will be shuffled in a manner that is progressive friendly. The
- * value can be multi-dimensional. For a given sequence, the seed value must be
- * constant. Table element size must be equal to or greater than 2^16. An index
- * greater than 2^16 will reuse table samples.
- *
- * @tparam Table Dimensional size of input table.
- * @tparam Depth Dimensional space of output, up to 4 dimensions.
-
- * @param [in] index Input index of sequence value.
- * @param [in] hash Hashed seed to randomise the sequence.
- * @param [in] table Pre-computed input table.
- * @param [out] sample Randomised sequence value.
- *
- * @pre Table input must be pre-computed using an initialisation function.
- */
+/// Compute a randomised value from a pre-computed table.
+/// Given an index and a seed, compute an scrambled sequence value. The index
+/// will be shuffled in a manner that is progressive friendly. The value can be
+/// multi-dimensional. For a given sequence, the seed value must be constant.
+/// Table element size must be equal to or greater than 2^16. An index greater
+/// than 2^16 will reuse table samples.
+///
+/// @tparam Table Dimensional size of input table.
+/// @tparam Depth Dimensional space of output, up to 4 dimensions.
+/// @param [in] index Input index of sequence value.
+/// @param [in] hash Hashed seed to randomise the sequence.
+/// @param [in] table Pre-computed input table.
+/// @param [out] sample Randomised sequence value.
+/// @pre Table input must be pre-computed using an initialisation function.
 template <int Table, int Depth>
 OQMC_HOST_DEVICE inline void
 shuffledScrambledLookup(std::uint32_t index, std::uint32_t hash,

--- a/include/oqmc/oqmc.h
+++ b/include/oqmc/oqmc.h
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Convenience header to include all sampler implementations. It is
- * worth noting that including a specific implementation header will improve
- * compile times.
- */
+/// @file
+/// @details Convenience header to include all sampler implementations. It is
+/// worth noting that including a specific implementation header will improve
+/// compile times.
 
 #pragma once
 

--- a/include/oqmc/owen.h
+++ b/include/oqmc/owen.h
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details An efficient implementation of Owen scrambled sobol sequences. This
- * can be used to construct higher level sampler types. The method uses Brent
- * Burley's hash based 'Practical Hash-based Owen Scrambling' construction with
- * added optimisations.
- */
+/// @file
+/// @details An efficient implementation of Owen scrambled sobol sequences. This
+/// can be used to construct higher level sampler types. The method uses Brent
+/// Burley's hash based 'Practical Hash-based Owen Scrambling' construction with
+/// added optimisations.
 
 #pragma once
 
@@ -36,16 +34,14 @@
 namespace oqmc
 {
 
-/**
- * @brief Compute sobol sequence value at an index with reversed bits.
- * @details Given a 16 bit index, where the order of bits in the index have
- * been reversed, compute a sobol sequence value to 16 bits of precision for a
- * given dimension. Dimensions must be within the range [0, 4).
- *
- * @param [in] index Bit reversed index of element.
- * @param [in] dimension Dimension of sobol sequence.
- * @return Sobol sequence value.
- */
+/// Compute sobol sequence value at an index with reversed bits.
+/// Given a 16 bit index, where the order of bits in the index have been
+/// reversed, compute a sobol sequence value to 16 bits of precision for a given
+/// dimension. Dimensions must be within the range [0, 4).
+///
+/// @param [in] index Bit reversed index of element.
+/// @param [in] dimension Dimension of sobol sequence.
+/// @return Sobol sequence value.
 OQMC_HOST_DEVICE inline std::uint16_t sobolReversedIndex(std::uint16_t index,
                                                          int dimension)
 {
@@ -256,17 +252,15 @@ OQMC_HOST_DEVICE inline std::uint16_t sobolReversedIndex(std::uint16_t index,
 #endif
 }
 
-/**
- * @brief Permute an input integer and reverse the bits.
- * @details Given an input integer value, perform a Laine and Karras style
- * permutation and reverse the resulting bits. The permutation can be randomised
- * with a given seed value. This will be equivalent to an Owen scramble when
- * the input bits of the integer are already reversed.
- *
- * @param [in] value Input integer value.
- * @param [in] seed Seed to change the permutation.
- * @return Permuted, reversed value.
- */
+/// Permute an input integer and reverse the bits.
+/// Given an input integer value, perform a Laine and Karras style permutation
+/// and reverse the resulting bits. The permutation can be randomised with a
+/// given seed value. This will be equivalent to an Owen scramble when the input
+/// bits of the integer are already reversed.
+///
+/// @param [in] value Input integer value.
+/// @param [in] seed Seed to change the permutation.
+/// @return Permuted, reversed value.
 OQMC_HOST_DEVICE constexpr std::uint32_t scrambleAndReverse(std::uint32_t value,
                                                             std::uint32_t seed)
 {
@@ -276,19 +270,16 @@ OQMC_HOST_DEVICE constexpr std::uint32_t scrambleAndReverse(std::uint32_t value,
 	return value;
 }
 
-/**
- * @brief Compute a randomised sobol sequence value.
- * @details Given an index and a seed, compute an Owen scrambled sobol sequence
- * value. The index will be shuffled in a manner that is progressive friendly.
- * The value can be multi-dimensional. For a given sequence, the seed value must
- * be constant. An index greater than 2^16 will repeat values.
- *
- * @tparam Depth Dimensional space of output, up to 4 dimensions.
-
- * @param [in] index Input index of sequence value.
- * @param [in] seed Seed to randomise the sequence.
- * @param [out] sample Randomised sequence value.
- */
+/// Compute a randomised sobol sequence value.
+/// Given an index and a seed, compute an Owen scrambled sobol sequence value.
+/// The index will be shuffled in a manner that is progressive friendly. The
+/// value can be multi-dimensional. For a given sequence, the seed value must be
+/// constant. An index greater than 2^16 will repeat values.
+///
+/// @tparam Depth Dimensional space of output, up to 4 dimensions.
+/// @param [in] index Input index of sequence value.
+/// @param [in] seed Seed to randomise the sequence.
+/// @param [out] sample Randomised sequence value.
 template <int Depth>
 OQMC_HOST_DEVICE inline void shuffledScrambledSobol(std::uint32_t index,
                                                     std::uint32_t seed,

--- a/include/oqmc/pcg.h
+++ b/include/oqmc/pcg.h
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details An implementation of a pseudo random number generator (PRNG) by
- * Melissa E. O'Neill. Specifically the insecure PCG-RXS-M-RX-32 (commonly
- * referred to as PCG), as this meets the criteria required by higher level
- * functionality in the library. Further details are in 'PCG: A Family of
- * Simple Fast Space-Efficient Statistically Good Algorithms for Random Number
- * Generation'. This is also used to construct a hash function as described in
- * 'Hash Functions for GPU Rendering' by Mark Jarzynski and Marc Olano. The
- * constant coefficients for the PCG-RXS-M-RX-32 implementation were taken from
- * 'https:// github.com/imneme/pcg-c'.
- */
+/// @file
+/// @details An implementation of a pseudo random number generator (PRNG) by
+/// Melissa E. O'Neill. Specifically the insecure PCG-RXS-M-RX-32 (commonly
+/// referred to as PCG), as this meets the criteria required by higher level
+/// functionality in the library. Further details are in 'PCG: A Family of
+/// Simple Fast Space-Efficient Statistically Good Algorithms for Random Number
+/// Generation'. This is also used to construct a hash function as described in
+/// 'Hash Functions for GPU Rendering' by Mark Jarzynski and Marc Olano. The
+/// constant coefficients for the PCG-RXS-M-RX-32 implementation were taken from
+/// https://github.com/imneme/pcg-c.
 
 #pragma once
 
@@ -27,35 +25,29 @@ namespace oqmc
 namespace pcg
 {
 
-/**
- * @brief State transition function.
- * @details Transition state using an LCG to increment the PRNG index along the
- * sequence. Incrementing the input state can be used to select a new sequence
- * stream. Note that you may want to use the higher level functionality below.
- *
- * @param [in] state Internal state of the PRNG.
- * @return State after incrementation of index.
- *
- * @pre State must have been initialised using an init function.
- */
+/// State transition function.
+/// Transition state using an LCG to increment the PRNG index along the
+/// sequence. Incrementing the input state can be used to select a new sequence
+/// stream. Note that you may want to use the higher level functionality below.
+///
+/// @param [in] state Internal state of the PRNG.
+/// @return State after incrementation of index.
+/// @pre State must have been initialised using an init function.
 OQMC_HOST_DEVICE constexpr std::uint32_t stateTransition(std::uint32_t state)
 {
 	// LCG
 	return state * 747796405u + 2891336453u;
 }
 
-/**
- * @brief Output permutation function.
- * @details Output permutation of the PRNG state, resulting in a usable
- * random value with good statistical properties. This implements the three
- * permutation operations used in PCG-RXS-M-32. Note you may want to use the
- * higher level functionality below.
- *
- * @param [in] state Internal state of the PRNG.
- * @return Output PRNG number from sequence.
- *
- * @pre State must have been initialised using an init function.
- */
+/// Output permutation function.
+/// Output permutation of the PRNG state, resulting in a usable random value
+/// with good statistical properties. This implements the three permutation
+/// operations used in PCG-RXS-M-32. Note you may want to use the higher level
+/// functionality below.
+///
+/// @param [in] state Internal state of the PRNG.
+/// @return Output PRNG number from sequence.
+/// @pre State must have been initialised using an init function.
 OQMC_HOST_DEVICE constexpr std::uint32_t output(std::uint32_t state)
 {
 	// RXS
@@ -70,61 +62,50 @@ OQMC_HOST_DEVICE constexpr std::uint32_t output(std::uint32_t state)
 	return state;
 }
 
-/**
- * @brief Default initialise the PRNG state.
- * @details If given no seed, initialise the PRNG state using a zero value.
- * This must be done prior to passing the state to other functionality within
- * this file.
- *
- * @return Initialised internal state of the PRNG.
- */
+/// Default initialise the PRNG state.
+/// If given no seed, initialise the PRNG state using a zero value. This must be
+/// done prior to passing the state to other functionality within this file.
+///
+/// @return Initialised internal state of the PRNG.
 OQMC_HOST_DEVICE constexpr std::uint32_t init()
 {
 	return stateTransition(0);
 }
 
-/**
- * @brief Initialise the PRNG state using a seed value.
- * @details If given a seed, initialise the PRNG state using said seed value.
- * This must be done prior to passing the state to other functionality within
- * this file.
- *
- * @param [in] seed Seed value for PRNG sequence.
- * @return Initialised internal state of the PRNG.
- */
+/// Initialise the PRNG state using a seed value.
+/// If given a seed, initialise the PRNG state using said seed value. This must
+/// be done prior to passing the state to other functionality within this file.
+///
+/// @param [in] seed Seed value for PRNG sequence.
+/// @return Initialised internal state of the PRNG.
 OQMC_HOST_DEVICE constexpr std::uint32_t init(std::uint32_t seed)
 {
 	return init() + seed;
 }
 
-/**
- * @brief Compute a hash value based on an input key.
- * @details Given an input key, compute a random hash value. This can be used
- * to initialise a system or to compute an array of random values in parallel.
- *
- * @param [in] key Hash key value.
- * @return Output hash value.
- */
+/// Compute a hash value based on an input key.
+/// Given an input key, compute a random hash value. This can be used to
+/// initialise a system or to compute an array of random values in parallel.
+///
+/// @param [in] key Hash key value.
+/// @return Output hash value.
 OQMC_HOST_DEVICE constexpr std::uint32_t hash(std::uint32_t key)
 {
 	key = stateTransition(key);
 	return output(key);
 }
 
-/**
- * @brief Compute a random number from the PRNG sequence.
- * @details Given a PRNG state, compute the next random number, and iterate the
- * state for the next value in the sequence. Useful for generating high quality
- * random numbers when computing them sequentially. The output number will be
- * in the range of an unsigned 32 bit integer. For floating point numbers, this
- * integer value needs to be converted into a floating point representation by
- * the calling code.
- *
- * @param [in, out] state State value of the PRNG. Will be mutated.
- * @return Output PRNG value from the sequence.
- *
- * @pre State must have been initialised using an init function.
- */
+/// Compute a random number from the PRNG sequence.
+/// Given a PRNG state, compute the next random number, and iterate the state
+/// for the next value in the sequence. Useful for generating high quality
+/// random numbers when computing them sequentially. The output number will be
+/// in the range of an unsigned 32 bit integer. For floating point numbers, this
+/// integer value needs to be converted into a floating point representation by
+/// the calling code.
+///
+/// @param [in, out] state State value of the PRNG. Will be mutated.
+/// @return Output PRNG value from the sequence.
+/// @pre State must have been initialised using an init function.
 OQMC_HOST_DEVICE constexpr std::uint32_t rng(std::uint32_t& state)
 {
 	state = stateTransition(state);

--- a/include/oqmc/permute.h
+++ b/include/oqmc/permute.h
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details An implementation for hash based permutations. A requirement when
- * constructing scrambling or randomisation of progressive sequences. This is
- * a variant of the hash originally published by Samuli Laine and Tero Karras
- * in 'Stratified Sampling for Stochastic Transparency'. But was then later
- * improved upon by Nathan Vegdahl in an article at https://psychopath.io/
- * post/2021_01_30_building_a_better_lk_hash.
- */
+/// @file
+/// @details An implementation for hash based permutations. A requirement when
+/// constructing scrambling or randomisation of progressive sequences. This is a
+/// variant of the hash originally published by Samuli Laine and Tero Karras in
+/// 'Stratified Sampling for Stochastic Transparency'. But was then later
+/// improved upon by Nathan Vegdahl in an article at
+/// https://psychopath.io/post/2021_01_30_building_a_better_lk_hash.
 
 #pragma once
 
@@ -21,21 +19,18 @@
 namespace oqmc
 {
 
-/**
- * @brief Laine and Karras style permutation.
- * @details Given an unsigned integer number, permute the bits so that lower
- * bits effect higher bits, but not the other way around. When combined with a
- * reversal of bits before and after, this forms an efficient hash based owen
- * scrambling scheme.
- *
- * @param [in] value Integer value to permute.
- * @param [in] seed Seed value to randomise the permutation.
- * @return Permuted output value.
- */
+/// Laine and Karras style permutation.
+/// Given an unsigned integer number, permute the bits so that lower bits effect
+/// higher bits, but not the other way around. When combined with a reversal of
+/// bits before and after, this forms an efficient hash based owen scrambling
+/// scheme.
+///
+/// @param [in] value Integer value to permute.
+/// @param [in] seed Seed value to randomise the permutation.
+/// @return Permuted output value.
 OQMC_HOST_DEVICE constexpr std::uint32_t
 laineKarrasPermutation(std::uint32_t value, std::uint32_t seed)
 {
-	// https://psychopath.io/post/2021_01_30_building_a_better_lk_hash
 	value ^= value * 0x3d20adea;
 	value += seed;
 	value *= (seed >> 16) | 1;
@@ -45,15 +40,13 @@ laineKarrasPermutation(std::uint32_t value, std::uint32_t seed)
 	return value;
 }
 
-/**
- * @brief Reverse input bits and shuffle order.
- * @details Given an unsigned integer number, reverse the bit order and then
- * perform a Laine and Karras style permutation.
- *
- * @param [in] value Integer value to reverse and permute.
- * @param [in] seed Seed value to randomise the permutation.
- * @return Reversed and permuted output value.
- */
+/// Reverse input bits and shuffle order.
+/// Given an unsigned integer number, reverse the bit order and then perform a
+/// Laine and Karras style permutation.
+///
+/// @param [in] value Integer value to reverse and permute.
+/// @param [in] seed Seed value to randomise the permutation.
+/// @return Reversed and permuted output value.
 OQMC_HOST_DEVICE constexpr std::uint32_t reverseAndShuffle(std::uint32_t value,
                                                            std::uint32_t seed)
 {
@@ -63,16 +56,14 @@ OQMC_HOST_DEVICE constexpr std::uint32_t reverseAndShuffle(std::uint32_t value,
 	return value;
 }
 
-/**
- * @brief Compute a hash based owen scramble.
- * @details Given an unsigned integer, use a hash based technique to perform an
- * owen scramble. This can be used to scramble a value, or to shuffle the order
- * of a sequence in a progressive friendly manner.
- *
- * @param [in] value Integer value to be scrambled.
- * @param [in] seed Seed value to randomise the scramble.
- * @return Scrambled output value.
- */
+/// Compute a hash based owen scramble.
+/// Given an unsigned integer, use a hash based technique to perform an owen
+/// scramble. This can be used to scramble a value, or to shuffle the order of a
+/// sequence in a progressive friendly manner.
+///
+/// @param [in] value Integer value to be scrambled.
+/// @param [in] seed Seed value to randomise the scramble.
+/// @return Scrambled output value.
 OQMC_HOST_DEVICE constexpr std::uint32_t shuffle(std::uint32_t value,
                                                  std::uint32_t seed)
 {

--- a/include/oqmc/pmj.h
+++ b/include/oqmc/pmj.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Pmj sampler implementation.
- */
+/// @file
+/// @details Pmj sampler implementation.
 
 #pragma once
 
@@ -105,25 +103,22 @@ void PmjImpl::drawRnd(std::uint32_t rnd[Size]) const
 }
 /// @endcond
 
-/**
- * @brief Low discrepancy pmj sampler.
- * @details The implementation uses the stochastic method described by Helmer
- * et la. in 'Stochastic Generation of (t, s) Sample Sequences' to efficiently
- * construct a progressive multi-jittered (0,2) sequence. The first pair of
- * dimensions in a domain have the same intergration properties as the Sobol
- * implementation. However as the sequence doesn't extend to more than two
- * dimensions, the second pair is randomised relative to the first in a single
- * domain.
- *
- * This sampler pre-computes a base 4D pattern for all sample indices during
- * the cache initialisation. Permuted index values are then looked up from
- * memory at runtime, before being XOR scrambled. This amortises the cost of
- * initialisation. The rate of integration is very high, especially for the
- * first and second pairs of dimensions. You may however not want to use this
- * implementation if memory space or access is a concern.
- *
- * @ingroup samplers
- */
+/// Low discrepancy pmj sampler.
+/// The implementation uses the stochastic method described by Helmer et la. in
+/// 'Stochastic Generation of (t, s) Sample Sequences' to efficiently construct
+/// a progressive multi-jittered (0,2) sequence. The first pair of dimensions in
+/// a domain have the same intergration properties as the Sobol implementation.
+/// However as the sequence doesn't extend to more than two dimensions, the
+/// second pair is randomised relative to the first in a single domain.
+///
+/// This sampler pre-computes a base 4D pattern for all sample indices during
+/// the cache initialisation. Permuted index values are then looked up from
+/// memory at runtime, before being XOR scrambled. This amortises the cost of
+/// initialisation. The rate of integration is very high, especially for the
+/// first and second pairs of dimensions. You may however not want to use this
+/// implementation if memory space or access is a concern.
+///
+/// @ingroup samplers
 using PmjSampler = SamplerInterface<PmjImpl>;
 
 } // namespace oqmc

--- a/include/oqmc/pmjbn.h
+++ b/include/oqmc/pmjbn.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Pmjbn sampler implementation.
- */
+/// @file
+/// @details Pmjbn sampler implementation.
 
 #pragma once
 
@@ -131,13 +129,11 @@ void PmjBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 }
 /// @endcond
 
-/**
- * @brief Blue noise variant of pmj sampler.
- * @details Same as oqmc::PmjSampler, with additional spatial temporal blue
- * noise dithering between pixels, with progressive pixel sampling support.
- *
- * @ingroup samplers
- */
+/// Blue noise variant of pmj sampler.
+/// Same as oqmc::PmjSampler, with additional spatial temporal blue noise
+/// dithering between pixels, with progressive pixel sampling support.
+///
+/// @ingroup samplers
 using PmjBnSampler = SamplerInterface<PmjBnImpl>;
 
 } // namespace oqmc

--- a/include/oqmc/range.h
+++ b/include/oqmc/range.h
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Functionality for remapping integer values to within a bounded range
- * while retaining quality properties of random numbers at low cost.
- */
+/// @file
+/// @details Functionality for remapping integer values to within a bounded
+/// range while retaining quality properties of random numbers at low cost.
 
 #pragma once
 
@@ -17,28 +15,26 @@
 namespace oqmc
 {
 
-/**
- * @brief Compute an unsigned integer within 0-bounded half-open range.
- * @details Given a range defined using a single unsigned integer, map a full
- * range 32 bit unsigned integer into range.
- *
- * This function will avoid any division using a multiplication method that
- * preserves the high order bits. This means that PRNGs with weak low order
- * bits, as welll as QMC sequences, will both retain their good properties.
- *
- * Due to these reasons, this function should be prefered over other naive
- * methods such as a modulo operator. It does however still introduce a form of
- * bias at large non power-of-two ranges. This could be resolved with a simple
- * extension ivolving a rejection method. However such methods do not integrate
- * well with the larger design, and so are not used as a practical compromise.
- *
- * For further information see Section 4 in https://arxiv.org/abs/1805.10941 as
- * well as https://www.pcg-random.org/posts/bounded-rands.html from PCG.
- *
- * @param [in] value Full ranged 32 bit unsigned integer.
- * @param [in] range Exclusive end of integer range. Greater than zero.
- * @return Output value remapped within integer range.
- */
+/// Compute an unsigned integer within 0-bounded half-open range.
+/// Given a range defined using a single unsigned integer, map a full range 32
+/// bit unsigned integer into range.
+///
+/// This function will avoid any division using a multiplication method that
+/// preserves the high order bits. This means that PRNGs with weak low order
+/// bits, as welll as QMC sequences, will both retain their good properties.
+///
+/// Due to these reasons, this function should be prefered over other naive
+/// methods such as a modulo operator. It does however still introduce a form of
+/// bias at large non power-of-two ranges. This could be resolved with a simple
+/// extension ivolving a rejection method. However such methods do not integrate
+/// well with the larger design, and so are not used as a practical compromise.
+///
+/// For further information see Section 4 in https://arxiv.org/abs/1805.10941 as
+/// well as https://www.pcg-random.org/posts/bounded-rands.html from PCG.
+///
+/// @param [in] value Full ranged 32 bit unsigned integer.
+/// @param [in] range Exclusive end of integer range. Greater than zero.
+/// @return Output value remapped within integer range.
 OQMC_HOST_DEVICE constexpr std::uint32_t uintToRange(std::uint32_t value,
                                                      std::uint32_t range)
 {
@@ -51,17 +47,15 @@ OQMC_HOST_DEVICE constexpr std::uint32_t uintToRange(std::uint32_t value,
 	return x * y >> 32;
 }
 
-/**
- * @brief Compute an unsigned integer within half-open range.
- * @details Given a range defined using two unsigned integers, map a full range
- * 32 bit unsigned integer into range. This function is based upon the other
- * uint to range function and has the same properties.
- *
- * @param [in] value Full ranged 32 bit unsigned integer.
- * @param [in] begin Inclusive beginning of integer range. Less than end.
- * @param [in] end Exclusive end of integer range. Greater than begin.
- * @return Output value remapped within integer range.
- */
+/// Compute an unsigned integer within half-open range.
+/// Given a range defined using two unsigned integers, map a full range 32 bit
+/// unsigned integer into range. This function is based upon the other uint to
+/// range function and has the same properties.
+///
+/// @param [in] value Full ranged 32 bit unsigned integer.
+/// @param [in] begin Inclusive beginning of integer range. Less than end.
+/// @param [in] end Exclusive end of integer range. Greater than begin.
+/// @return Output value remapped within integer range.
 OQMC_HOST_DEVICE constexpr std::uint32_t
 uintToRange(std::uint32_t value, std::uint32_t begin, std::uint32_t end)
 {

--- a/include/oqmc/rank1.h
+++ b/include/oqmc/rank1.h
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details An implementation of a rank 1 lattice as described in 'Weighted
- * Compound Integration Rules with Higher Order Convergence for all N' by Fred
- * J. Hickernell, et al., made progressive with a radical inversion of the
- * sample index.
- */
+/// @file
+/// @details An implementation of a rank 1 lattice as described in 'Weighted
+/// Compound Integration Rules with Higher Order Convergence for all N' by Fred
+/// J. Hickernell, et al., made progressive with a radical inversion of the
+/// sample index.
 
 #pragma once
 
@@ -21,35 +19,30 @@
 namespace oqmc
 {
 
-/**
- * @brief Rotate an integer a given distance.
- * @details Given a 32 bit unsigned integer value, offset the value a given
- * distance, and rely on integer overflow for the value to wrap around. When
- * applied to elements in a lattice, this represents a toroidal shift or
- * rotation, upon the range of representable values. When the distance is
- * constant for all elements, this can be used to efficiently randomise the
- * values.
- *
- * @param [in] value Integer value to offset.
- * @param [in] distance Distance to offset value.
- * @return Rotated integer value.
- */
+/// Rotate an integer a given distance.
+/// Given a 32 bit unsigned integer value, offset the value a given distance,
+/// and rely on integer overflow for the value to wrap around. When applied to
+/// elements in a lattice, this represents a toroidal shift or rotation, upon
+/// the range of representable values. When the distance is constant for all
+/// elements, this can be used to efficiently randomise the values.
+///
+/// @param [in] value Integer value to offset.
+/// @param [in] distance Distance to offset value.
+/// @return Rotated integer value.
 OQMC_HOST_DEVICE constexpr std::uint32_t rotate(std::uint32_t value,
                                                 std::uint32_t distance)
 {
 	return value + distance;
 }
 
-/**
- * @brief Compute a rank 1 lattice value at an index with reversed bits.
- * @details Given a 32 bit index, where the order of bits in the index have
- * been reversed, compute a rank 1 lattice value to 32 bits of precision for a
- * given dimension. Dimensions must be within the range [0, 4).
- *
- * @param [in] index Bit reversed index of element.
- * @param [in] dimension Dimension of rank 1 lattice.
- * @return Rank 1 lattice value.
- */
+/// Compute a rank 1 lattice value at an index with reversed bits.
+/// Given a 32 bit index, where the order of bits in the index have been
+/// reversed, compute a rank 1 lattice value to 32 bits of precision for a given
+/// dimension. Dimensions must be within the range [0, 4).
+///
+/// @param [in] index Bit reversed index of element.
+/// @param [in] dimension Dimension of rank 1 lattice.
+/// @return Rank 1 lattice value.
 OQMC_HOST_DEVICE constexpr std::uint32_t
 latticeReversedIndex(std::uint32_t index, int dimension)
 {
@@ -68,19 +61,16 @@ latticeReversedIndex(std::uint32_t index, int dimension)
 	return lattice[dimension] * index;
 }
 
-/**
- * @brief Compute a randomised rank 1 lattice value.
- * @details Given an index and a patternId, compute a rank 1 lattice value. The
- * index will be shuffled in a manner that is progressive friendly. The value
- * can be multi-dimensional. For a given lattice, the patternId value must
- * be constant.
- *
- * @tparam Depth Dimensional space of output, up to 4 dimensions.
-
- * @param [in] index Input index of lattice value.
- * @param [in] patternId Seed to randomise the lattice.
- * @param [out] sample Randomised lattice value.
- */
+/// Compute a randomised rank 1 lattice value.
+/// Given an index and a patternId, compute a rank 1 lattice value. The index
+/// will be shuffled in a manner that is progressive friendly. The value can be
+/// multi-dimensional. For a given lattice, the patternId value must be
+/// constant.
+///
+/// @tparam Depth Dimensional space of output, up to 4 dimensions.
+/// @param [in] index Input index of lattice value.
+/// @param [in] patternId Seed to randomise the lattice.
+/// @param [out] sample Randomised lattice value.
 template <int Depth>
 OQMC_HOST_DEVICE constexpr void
 shuffledRotatedLattice(std::uint32_t index, std::uint32_t patternId,

--- a/include/oqmc/reverse.h
+++ b/include/oqmc/reverse.h
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Functions to reverse the order of bits in integer data types. This
- * operation is also known as a radical inversion or a Van der Corput sequence.
- */
+/// @file
+/// @details Functions to reverse the order of bits in integer data types. This
+/// operation is also known as a radical inversion or a Van der Corput sequence.
 
 #pragma once
 
@@ -16,14 +14,12 @@
 namespace oqmc
 {
 
-/**
- * @brief Reverse bits of an unsigned 32 bit integer.
- * @details Given a 32 bit unsigned integer value, reverse the order of bits so
- * that the most significant bits become the least significant, and vise versa.
- *
- * @param [in] value Integer value to reverse.
- * @return Reversed integer value.
- */
+/// Reverse bits of an unsigned 32 bit integer.
+/// Given a 32 bit unsigned integer value, reverse the order of bits so that the
+/// most significant bits become the least significant, and vise versa.
+///
+/// @param [in] value Integer value to reverse.
+/// @return Reversed integer value.
 OQMC_HOST_DEVICE constexpr std::uint32_t reverseBits32(std::uint32_t value)
 {
 #if defined(__CUDA_ARCH__)
@@ -44,14 +40,12 @@ OQMC_HOST_DEVICE constexpr std::uint32_t reverseBits32(std::uint32_t value)
 	return value;
 }
 
-/**
- * @brief Reverse bits of an unsigned 16 bit integer.
- * @details Given a 16 bit unsigned integer value, reverse the order of bits so
- * that the most significant bits become the least significant, and vise versa.
- *
- * @param [in] value Integer value to reverse.
- * @return Reversed integer value.
- */
+/// Reverse bits of an unsigned 16 bit integer.
+/// Given a 16 bit unsigned integer value, reverse the order of bits so that the
+/// most significant bits become the least significant, and vise versa.
+///
+/// @param [in] value Integer value to reverse.
+/// @return Reversed integer value.
 OQMC_HOST_DEVICE constexpr std::uint16_t reverseBits16(std::uint16_t value)
 {
 #if defined(__CUDA_ARCH__)

--- a/include/oqmc/rotate.h
+++ b/include/oqmc/rotate.h
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Bit rotatation function implementations. These can be used to
- * extract new random values from already estisting hash or rng numbers.
- */
+/// @file
+/// @details Bit rotatation function implementations. These can be used to
+/// extract new random values from already estisting hash or rng numbers.
 
 #pragma once
 
@@ -16,30 +14,26 @@
 namespace oqmc
 {
 
-/**
- * @brief Rotate bits in an integer value.
- * @details Offset bits in a 32 bit integer a given distance, while wrapping
- * the bits so that the value remains the same every distance multiplier of 32.
- *
- * @param [in] value Initial integer of bits.
- * @param [in] distance Distance to offset.
- * @return Input value after bit rotation.
- */
+/// Rotate bits in an integer value.
+/// Offset bits in a 32 bit integer a given distance, while wrapping the bits so
+/// that the value remains the same every distance multiplier of 32.
+///
+/// @param [in] value Initial integer of bits.
+/// @param [in] distance Distance to offset.
+/// @return Input value after bit rotation.
 OQMC_HOST_DEVICE constexpr std::uint32_t rotateBits(std::uint32_t value,
                                                     std::uint32_t distance)
 {
 	return value >> (+distance & 31) | value << (-distance & 31);
 }
 
-/**
- * @brief Rotate bytes in an integer value.
- * @details Offset bytes in a 4 byte integer a given distance, while wrapping
- * the bytes so that the value remains the same every distance multiplier of 4.
- *
- * @param [in] value Initial integer of bits.
- * @param [in] distance Distance to offset.
- * @return Input value after byte rotation.
- */
+/// Rotate bytes in an integer value.
+/// Offset bytes in a 4 byte integer a given distance, while wrapping the bytes
+/// so that the value remains the same every distance multiplier of 4.
+///
+/// @param [in] value Initial integer of bits.
+/// @param [in] distance Distance to offset.
+/// @return Input value after byte rotation.
 OQMC_HOST_DEVICE constexpr std::uint32_t rotateBytes(std::uint32_t value,
                                                      int distance)
 {

--- a/include/oqmc/sampler.h
+++ b/include/oqmc/sampler.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Sampler interface definition.
- */
+/// @file
+/// @details Sampler interface definition.
 
 #pragma once
 
@@ -16,103 +14,98 @@
 #include <cstddef>
 #include <cstdint>
 
-/**
- * @defgroup samplers Sampler API
- * @brief Higher level sampler API and sampler types.
- * @details This module outlines the higher level sampler API, as well as each
- * availble sampler type. Sampler type implementations are non-public, and all
- * functionality is accessible via the SamplerInterface. There are two variants
- * for each sampler, a base variant and a blue noise variant. Sampler types and
- * a corresponding header file are listed under Typedef Documentation.
- *
- * **Blue noise sampler variants**
- *
- * Blue noise variants offer spatial temporal blue noise dithering between
- * pixels, with progressive pixel sampling. This is done using an offline
- * optimisation process that is based on the work by Belcour and Heitz in
- * 'Lessons Learned and Improvements when Building Screen-Space Samplers with
- * Blue-Noise Error Distribution', and extends temporally as described by Wolfe
- * et al. in 'Spatiotemporal Blue Noise Masks'.
- *
- * Each variant achieves a blue noise distribution using two pixel tables, one
- * holds keys to seed the sequence, and the other index ranks. These tables
- * are then randomised by toroidally shifting the table lookups for each domain
- * using random offsets. Correlation between the offsets and the pixels allows
- * for a single pair of tables to provide keys and ranks for all domains.
- *
- * Although the spatial temporal blue noise does not reduce the error for
- * an individual pixel, it does give a better perceptual result due to less
- * low frequency structure in the error between pixels. Also, if an image
- * is either spatially or temporally filtered (as with denoising or temporal
- * anti-aliasing), the resulting error can be lower when using a blue noise
- * variant.
- *
- * Blue noise variants are recommended, as the additional performance cost will
- * likely be a favourable tradeoff for the quality gains at low sample counts.
- * However, access to the data tables can impact performance depending on the
- * architecture (e.g. GPU), so it is worth benchmarking if this is a concern.
- *
- * **Passing and packing samplers**
- *
- * Sampler objects can be efficiently passed by value into functions, as well
- * as packed and queued for deferred evaluation. Achieving this means that the
- * memory footprint of a sampler must be very small, and the type trivially
- * copyable.
- *
- * Sampler types are either 8 or 16 bytes in size depending on the type. The
- * small memory footprint is possible due to the state size of PCG-RXS-M-RX-32
- * from the PCG family of PRNGs as described by O'Neill in 'PCG: A Family of
- * Simple Fast Space-Efficient Statistically Good Algorithms for Random Number
- * Generation'.
- *
- * When deriving domains the sampler will use an LCG state transition, and
- * only perform a permutation prior to drawing samples analogous to PCG. This
- * provides high quality bits when drawing samples, but keeps the cost low when
- * deriving domains, which might not be used.
- */
+/// @defgroup samplers Sampler API
+/// Higher level sampler API and sampler types.
+/// This module outlines the higher level sampler API, as well as each availble
+/// sampler type. Sampler type implementations are non-public, and all
+/// functionality is accessible via the SamplerInterface. There are two variants
+/// for each sampler, a base variant and a blue noise variant. Sampler types and
+/// a corresponding header file are listed under Typedef Documentation.
+///
+/// **Blue noise sampler variants**
+///
+/// Blue noise variants offer spatial temporal blue noise dithering between
+/// pixels, with progressive pixel sampling. This is done using an offline
+/// optimisation process that is based on the work by Belcour and Heitz in
+/// 'Lessons Learned and Improvements when Building Screen-Space Samplers with
+/// Blue-Noise Error Distribution', and extends temporally as described by Wolfe
+/// et al. in 'Spatiotemporal Blue Noise Masks'.
+///
+/// Each variant achieves a blue noise distribution using two pixel tables, one
+/// holds keys to seed the sequence, and the other index ranks. These tables
+/// are then randomised by toroidally shifting the table lookups for each domain
+/// using random offsets. Correlation between the offsets and the pixels allows
+/// for a single pair of tables to provide keys and ranks for all domains.
+///
+/// Although the spatial temporal blue noise does not reduce the error for
+/// an individual pixel, it does give a better perceptual result due to less
+/// low frequency structure in the error between pixels. Also, if an image
+/// is either spatially or temporally filtered (as with denoising or temporal
+/// anti-aliasing), the resulting error can be lower when using a blue noise
+/// variant.
+///
+/// Blue noise variants are recommended, as the additional performance cost will
+/// likely be a favourable tradeoff for the quality gains at low sample counts.
+/// However, access to the data tables can impact performance depending on the
+/// architecture (e.g. GPU), so it is worth benchmarking if this is a concern.
+///
+/// **Passing and packing samplers**
+///
+/// Sampler objects can be efficiently passed by value into functions, as well
+/// as packed and queued for deferred evaluation. Achieving this means that the
+/// memory footprint of a sampler must be very small, and the type trivially
+/// copyable.
+///
+/// Sampler types are either 8 or 16 bytes in size depending on the type. The
+/// small memory footprint is possible due to the state size of PCG-RXS-M-RX-32
+/// from the PCG family of PRNGs as described by O'Neill in 'PCG: A Family of
+/// Simple Fast Space-Efficient Statistically Good Algorithms for Random Number
+/// Generation'.
+///
+/// When deriving domains the sampler will use an LCG state transition, and
+/// only perform a permutation prior to drawing samples analogous to PCG. This
+/// provides high quality bits when drawing samples, but keeps the cost low when
+/// deriving domains, which might not be used.
 
 namespace oqmc
 {
 
-/**
- * @brief Public sampler API.
- * @details This is a sampler interface that defines a generic API for all
- * sampler types. The interface is composed of an internal implementation,
- * meaning only this public API is exposed to calling code.
- *
- * @internal
- * New implementations should define an implementation type, and pass this type
- * as a template parameter to an instantiation of SamplerInterface.
- *
- * @code
- * class FooImpl
- * {
- * ...
- * }
- *
- * using FooSampler = SamplerInterface<FooImpl>;
- * @endcode
- *
- * Samplers should aim to have a small memory footprint, and be cheap to copy,
- * allowing copy by value when passing as a function argument.
- * @endinternal
- *
- * Different samplers defined using the interface should be interchangeable
- * allowing for new implementations to be tested and compared without changing
- * the calling code. The interface is static, so all functions should be inlined
- * to allow for zero cost abstraction. This also means that enabling compile
- * time optimisations might provide a noticable improvement.
- *
- * Samplers can only be constructed, their state cannot change. In most cases
- * the object variable can be marked constant. New samplers are created from
- * a parent sampler using the newDomain member functions. Sample values are
- * retrieved using the draw member functions. Calls to newDomain functions
- * should be cheap in comparison to calls to draw functions.
- *
- * @ingroup samplers
- *
- * @tparam Impl Internal sampler implementation type as described above.
- */
+/// Public sampler API.
+/// This is a sampler interface that defines a generic API for all sampler
+/// types. The interface is composed of an internal implementation, meaning only
+/// this public API is exposed to calling code.
+///
+/// @internal
+/// New implementations should define an implementation type, and pass this type
+/// as a template parameter to an instantiation of SamplerInterface.
+///
+/// @code
+/// class FooImpl
+/// {
+/// ...
+/// }
+///
+/// using FooSampler = SamplerInterface<FooImpl>;
+/// @endcode
+///
+/// Samplers should aim to have a small memory footprint, and be cheap to copy,
+/// allowing copy by value when passing as a function argument.
+/// @endinternal
+///
+/// Different samplers defined using the interface should be interchangeable
+/// allowing for new implementations to be tested and compared without changing
+/// the calling code. The interface is static, so all functions should be
+/// inlined to allow for zero cost abstraction. This also means that enabling
+/// compile time optimisations might provide a noticable improvement.
+///
+/// Samplers can only be constructed, their state cannot change. In most cases
+/// the object variable can be marked constant. New samplers are created from a
+/// parent sampler using the newDomain member functions. Sample values are
+/// retrieved using the draw member functions. Calls to newDomain functions
+/// should be cheap in comparison to calls to draw functions.
+///
+/// @ingroup samplers
+/// @tparam Impl Internal sampler implementation type as described above.
 template <typename Impl>
 class SamplerInterface
 {
@@ -126,244 +119,210 @@ class SamplerInterface
 	Impl impl;
 
   public:
-	/**
-	 * @brief Required allocation size of the cache.
-	 * @details Prior to construction of a sampler object, a cache needs to be
-	 * allocated and initialised for any given sampler type. This variable is
-	 * the minimum required size in bytes of that allocation. The allocation
-	 * itself is performed and owned by the caller. Responsibility for the
-	 * de-allocation is also that of the caller.
-	 */
+	/// Required allocation size of the cache.
+	/// Prior to construction of a sampler object, a cache needs to be allocated
+	/// and initialised for any given sampler type. This variable is the minimum
+	/// required size in bytes of that allocation. The allocation itself is
+	/// performed and owned by the caller. Responsibility for the de-allocation
+	/// is also that of the caller.
 	static constexpr std::size_t cacheSize = Impl::cacheSize;
 
-	/**
-	 * @brief Initialise the cache allocation.
-	 * @details Prior to construction of a sampler object, a cache needs to be
-	 * allocated and initialised for any given sampler type. This function will
-	 * initialise that allocation. Once the cache is initialised it may be used
-	 * to construct a sampler object, or copied to a new address.
-	 *
-	 * Care must be taken to make sure the memory address is accessible at the
-	 * point of construction. On the CPU this is trivial. But when constructing
-	 * a sampler object on the GPU, the caller is expected to either use unified
-	 * memory for the allocation, or manually copy the memory from the host to
-	 * the device after the cache has been initialised.
-	 *
-	 * A single cache (for each sampler type) is expected to be constructed only
-	 * once for the duration of a calling process. This single cache can be used
-	 * to construct many sampler objects.
-	 *
-	 * @param [in, out] cache Memory address of the cache allocation.
-	 *
-	 * @pre Memory for the cache must be allocated prior. The minimum size of
-	 * the allocation can be retrieved using the `cacheSize` variable above.
-	 *
-	 * @post Memory for the cache must be de-allocated after all instances of
-	 * the sampler object have been destroyed.
-	 */
+	/// Initialise the cache allocation.
+	/// Prior to construction of a sampler object, a cache needs to be allocated
+	/// and initialised for any given sampler type. This function will
+	/// initialise that allocation. Once the cache is initialised it may be used
+	/// to construct a sampler object, or copied to a new address.
+	///
+	/// Care must be taken to make sure the memory address is accessible at the
+	/// point of construction. On the CPU this is trivial. But when constructing
+	/// a sampler object on the GPU, the caller is expected to either use
+	/// unified memory for the allocation, or manually copy the memory from the
+	/// host to the device after the cache has been initialised.
+	///
+	/// A single cache (for each sampler type) is expected to be constructed
+	/// only once for the duration of a calling process. This single cache can
+	/// be used to construct many sampler objects.
+	///
+	/// @param [in, out] cache Memory address of the cache allocation.
+	/// @pre Memory for the cache must be allocated prior. The minimum size of
+	/// the allocation can be retrieved using the `cacheSize` variable above.
+	/// @post Memory for the cache must be de-allocated after all instances of
+	/// the sampler object have been destroyed.
 	static void initialiseCache(void* cache);
 
-	/**
-	 * @brief Construct an invalid object.
-	 * @details Create a placeholder object to allocate containers, etc. The
-	 * resulting object is invalid, and you should initialise it by replacing
-	 * the object with another from a parametrised constructor.
-	 */
+	/// Construct an invalid object.
+	/// Create a placeholder object to allocate containers, etc. The resulting
+	/// object is invalid, and you should initialise it by replacing the object
+	/// with another from a parametrised constructor.
 	/*AUTO_DEFINED*/ SamplerInterface() = default;
 
-	/**
-	 * @brief Parametrised pixel constructor.
-	 * @details Create an object based on the pixel, frame and sample indices.
-	 * This also requires a pre-allocated and initialised cache. Once
-	 * constructed the object is valid and ready for use.
-	 *
-	 * For each pixel this constructor is expected to be called multiple times,
-	 * once for each index. Pixels might have a varying number of indicies when
-	 * adaptive sampling.
-	 *
-	 * @param [in] x Pixel coordinate on the x axis.
-	 * @param [in] y Pixel coordinate on the y axis.
-	 * @param [in] frame Time index value.
-	 * @param [in] index Sample index. Must be positive.
-	 * @param [in] cache Allocated and initialised cache.
-	 *
-	 * @pre Cache has been allocated in memory accessible to the device calling
-	 * this constructor, and has also been initialised.
-	 */
+	/// Parametrised pixel constructor.
+	/// Create an object based on the pixel, frame and sample indices. This also
+	/// requires a pre-allocated and initialised cache. Once constructed the
+	/// object is valid and ready for use.
+	///
+	/// For each pixel this constructor is expected to be called multiple times,
+	/// once for each index. Pixels might have a varying number of indicies when
+	/// adaptive sampling.
+	///
+	/// @param [in] x Pixel coordinate on the x axis.
+	/// @param [in] y Pixel coordinate on the y axis.
+	/// @param [in] frame Time index value.
+	/// @param [in] index Sample index. Must be positive.
+	/// @param [in] cache Allocated and initialised cache.
+	/// @pre Cache has been allocated in memory accessible to the device calling
+	/// this constructor, and has also been initialised.
 	OQMC_HOST_DEVICE SamplerInterface(int x, int y, int frame, int index,
 	                                  const void* cache);
 
-	/**
-	 * @brief Derive an object in a new domain.
-	 * @details The function derives a mutated copy of the current sampler
-	 * object. This new object is called a domain. Each domain produces an
-	 * independent 4 dimensional pattern. Calling the draw* member functions
-	 * below on the new child domain will produce a different value to that of
-	 * the current parent domain.
-	 *
-	 * N child domains can be derived from a single parent domain with the use
-	 * of the key argument. Keys must have at least one bit difference, but can
-	 * be a simple incrementing sequence. A single child domain can itself
-	 * derive N child domains. This process results in a domain tree.
-	 *
-	 * The calling code can use up to 4 dimensions from each domain (these are
-	 * typically of the highest quality), joining them together to form an N
-	 * dimensional pattern. This technique is called padding.
-	 *
-	 * @param [in] key Index key of next domain.
-	 * @return Child domain based on the current object state and key.
-	 */
+	/// Derive an object in a new domain.
+	/// The function derives a mutated copy of the current sampler object. This
+	/// new object is called a domain. Each domain produces an independent 4
+	/// dimensional pattern. Calling the draw* member functions below on the new
+	/// child domain will produce a different value to that of the current
+	/// parent domain.
+	///
+	/// N child domains can be derived from a single parent domain with the use
+	/// of the key argument. Keys must have at least one bit difference, but can
+	/// be a simple incrementing sequence. A single child domain can itself
+	/// derive N child domains. This process results in a domain tree.
+	///
+	/// The calling code can use up to 4 dimensions from each domain (these are
+	/// typically of the highest quality), joining them together to form an N
+	/// dimensional pattern. This technique is called padding.
+	///
+	/// @param [in] key Index key of next domain.
+	/// @return Child domain based on the current object state and key.
 	OQMC_HOST_DEVICE SamplerInterface newDomain(int key) const;
 
-	/**
-	 * @brief Derive an object in a new domain for a local distribution.
-	 * @details Like newDomain, this function derives a mutated copy of the
-	 * current sampler object. The difference is it decorrelates the pattern
-	 * with the sample index, allowing for sample splitting with a non-constant
-	 * or unknown multiplier.
-	 *
-	 * The result from taking N indexed domains with this function will be a
-	 * locally well distributed sub-pattern. This sub-pattern will be of lower
-	 * quality when combined with the sub-patterns of other samples. That is
-	 * because the correlation between the sub-patterns globally is lost.
-	 *
-	 * If a mutliplier is known and constant then newDomainSplit will produce
-	 * better quality sample points and should be used instead. This is because
-	 * newDomainSplit will preserved correlation between sub-patterns from other
-	 * samples.
-	 *
-	 * Calling code should use a constant key for any given domain while then
-	 * incrementing the index value N times to increase the sampling rate by N
-	 * for that given domain. The function will be called N times, once for each
-	 * unique index.
-	 *
-	 * @param [in] key Index key of next domain.
-	 * @param [in] index Sample index of next domain. Must be positive.
-	 * @return Child domain based on the current object state and key.
-	 */
+	/// Derive an object in a new domain for a local distribution.
+	/// Like newDomain, this function derives a mutated copy of the current
+	/// sampler object. The difference is it decorrelates the pattern with the
+	/// sample index, allowing for sample splitting with a non-constant or
+	/// unknown multiplier.
+	///
+	/// The result from taking N indexed domains with this function will be a
+	/// locally well distributed sub-pattern. This sub-pattern will be of lower
+	/// quality when combined with the sub-patterns of other samples. That is
+	/// because the correlation between the sub-patterns globally is lost.
+	///
+	/// If a mutliplier is known and constant then newDomainSplit will produce
+	/// better quality sample points and should be used instead. This is because
+	/// newDomainSplit will preserved correlation between sub-patterns from
+	/// other samples.
+	///
+	/// Calling code should use a constant key for any given domain while then
+	/// incrementing the index value N times to increase the sampling rate by N
+	/// for that given domain. The function will be called N times, once for
+	/// each unique index.
+	///
+	/// @param [in] key Index key of next domain.
+	/// @param [in] index Sample index of next domain. Must be positive.
+	/// @return Child domain based on the current object state and key.
 	OQMC_HOST_DEVICE SamplerInterface newDomainDistrib(int key,
 	                                                   int index) const;
 
-	/**
-	 * @brief Derive an object in a new domain for global splitting.
-	 * @details Like the other newDomain* functions, this function derives a
-	 * mutated copy of the current sampler object. The difference is it remaps
-	 * the sample index, allowing for sample splitting with a known and constant
-	 * multiplier.
-	 *
-	 * The result from taking N indexed domains with this function will be both
-	 * a locally and a gloablly well distributed sub-pattern. This sub-pattern
-	 * will of the highest quality due to being globally correlated with the
-	 * sub-patterns of other samples.
-	 *
-	 * If a mutliplier is non-constant or unknown then newDomainDistrib should
-	 * be used instead. This is because newDomainDistrib relaxes the constraints
-	 * in excahnge for a reduction in the global quality of the pattern.
-	 *
-	 * Calling code should use a constant key for any given domain while then
-	 * incrementing the index value N times to increase the sampling rate by N
-	 * for that given domain. The function will be called N times, once for each
-	 * unique index. N must be passed as 'size' and remain constant.
-	 *
-	 * @param [in] key Index key of next domain.
-	 * @param [in] size Sample index multiplier. Must greater than zero.
-	 * @param [in] index Sample index of next domain. Must be positive.
-	 * @return Child domain based on the current object state, key and size.
-	 */
+	/// Derive an object in a new domain for global splitting.
+	/// Like the other newDomain* functions, this function derives a mutated
+	/// copy of the current sampler object. The difference is it remaps the
+	/// sample index, allowing for sample splitting with a known and constant
+	/// multiplier.
+	///
+	/// The result from taking N indexed domains with this function will be both
+	/// a locally and a gloablly well distributed sub-pattern. This sub-pattern
+	/// will of the highest quality due to being globally correlated with the
+	/// sub-patterns of other samples.
+	///
+	/// If a mutliplier is non-constant or unknown then newDomainDistrib should
+	/// be used instead. This is because newDomainDistrib relaxes the
+	/// constraints in excahnge for a reduction in the global quality of the
+	/// pattern.
+	///
+	/// Calling code should use a constant key for any given domain while then
+	/// incrementing the index value N times to increase the sampling rate by N
+	/// for that given domain. The function will be called N times, once for
+	/// each unique index. N must be passed as 'size' and remain constant.
+	///
+	/// @param [in] key Index key of next domain.
+	/// @param [in] size Sample index multiplier. Must greater than zero.
+	/// @param [in] index Sample index of next domain. Must be positive.
+	/// @return Child domain based on the current object state, key and size.
 	OQMC_HOST_DEVICE SamplerInterface newDomainSplit(int key, int size,
 	                                                 int index) const;
 
-	/**
-	 * @brief Draw integer sample values from domain.
-	 * @details This can compute sample values with up to 4 dimensions for the
-	 * given domain. The operation does not change the state of the object, and
-	 * for a single domain and index, the result of this function will always be
-	 * the same. Output values are uniformly distributed integers within the
-	 * range of [0, 2^32).
-	 *
-	 * These values are of high quality and should be handled with care as to
-	 * not introduce bias into an estimate. For low quality, but fast and safe
-	 * random numbers, use the drawRnd member functions below.
-	 *
-	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
-	 *
-	 * @param [out] sample Output array to store sample values.
-	 */
+	/// Draw integer sample values from domain.
+	/// This can compute sample values with up to 4 dimensions for the given
+	/// domain. The operation does not change the state of the object, and for a
+	/// single domain and index, the result of this function will always be the
+	/// same. Output values are uniformly distributed integers within the range
+	/// of [0, 2^32).
+	///
+	/// These values are of high quality and should be handled with care as to
+	/// not introduce bias into an estimate. For low quality, but fast and safe
+	/// random numbers, use the drawRnd member functions below.
+	///
+	/// @tparam Size Number of dimensions to draw. Must be within [1, 4].
+	/// @param [out] sample Output array to store sample values.
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
 
-	/**
-	 * @brief Draw ranged integer sample values from domain.
-	 * @details This function wraps the integer variant of drawSample above. But
-	 * transforms the output values into uniformly distributed integers within
-	 * the range of [0, range).
-	 *
-	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
-	 *
-	 * @param [in] range Exclusive end of range. Greater than zero.
-	 * @param [out] sample Output array to store sample values.
-	 */
+	/// Draw ranged integer sample values from domain.
+	/// This function wraps the integer variant of drawSample above. But
+	/// transforms the output values into uniformly distributed integers within
+	/// the range of [0, range).
+	///
+	/// @tparam Size Number of dimensions to draw. Must be within [1, 4].
+	/// @param [in] range Exclusive end of range. Greater than zero.
+	/// @param [out] sample Output array to store sample values.
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t range,
 	                                 std::uint32_t sample[Size]) const;
 
-	/**
-	 * @brief Draw floating point sample values from domain.
-	 * @details This function wraps the integer variant of drawSample above. But
-	 * transforms the output values into uniformly distributed floats within the
-	 * range of [0, 1).
-	 *
-	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
-	 *
-	 * @param [out] sample Output array to store sample values.
-	 */
+	/// Draw floating point sample values from domain.
+	/// This function wraps the integer variant of drawSample above. But
+	/// transforms the output values into uniformly distributed floats within
+	/// the range of [0, 1).
+	///
+	/// @tparam Size Number of dimensions to draw. Must be within [1, 4].
+	/// @param [out] sample Output array to store sample values.
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(float sample[Size]) const;
 
-	/**
-	 * @brief Draw integer pseudo random values from domain.
-	 * @details This can compute rnd values with up to 4 dimensions for the
-	 * given domain. The operation does not change the state of the object, and
-	 * for a single domain and index, the result of this function will always be
-	 * the same. Output values are uniformly distributed integers within the
-	 * range of [0, 2^32).
-	 *
-	 * These values are of low quality but are fast to compute and have little
-	 * risk of biasing an estimate. For higher quality samples, use the
-	 * drawSample member functions above.
-	 *
-	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
-	 *
-	 * @param [out] rnd Output array to store rnd values.
-	 */
+	/// Draw integer pseudo random values from domain.
+	/// This can compute rnd values with up to 4 dimensions for the given
+	/// domain. The operation does not change the state of the object, and for a
+	/// single domain and index, the result of this function will always be the
+	/// same. Output values are uniformly distributed integers within the range
+	/// of [0, 2^32).
+	///
+	/// These values are of low quality but are fast to compute and have little
+	/// risk of biasing an estimate. For higher quality samples, use the
+	/// drawSample member functions above.
+	///
+	/// @tparam Size Number of dimensions to draw. Must be within [1, 4].
+	/// @param [out] rnd Output array to store rnd values.
 	template <int Size>
 	OQMC_HOST_DEVICE void drawRnd(std::uint32_t rnd[Size]) const;
 
-	/**
-	 * @brief Draw ranged integer pseudo random values from domain.
-	 * @details This function wraps the integer variant of drawRnd above. But
-	 * transforms the output values into uniformly distributed integers within
-	 * the range of [0, range).
-	 *
-	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
-	 *
-	 * @param [in] range Exclusive end of range. Greater than zero.
-	 * @param [out] rnd Output array to store rnd values.
-	 */
+	/// Draw ranged integer pseudo random values from domain.
+	/// This function wraps the integer variant of drawRnd above. But transforms
+	/// the output values into uniformly distributed integers within the range
+	/// of [0, range).
+	///
+	/// @tparam Size Number of dimensions to draw. Must be within [1, 4].
+	/// @param [in] range Exclusive end of range. Greater than zero.
+	/// @param [out] rnd Output array to store rnd values.
 	template <int Size>
 	OQMC_HOST_DEVICE void drawRnd(std::uint32_t range,
 	                              std::uint32_t rnd[Size]) const;
 
-	/**
-	 * @brief Draw floating point pseudo random values from domain.
-	 * @details This function wraps the integer variant of drawRnd above. But
-	 * transforms the output values into uniformly distributed floats within the
-	 * range of [0, 1).
-	 *
-	 * @tparam Size Number of dimensions to draw. Must be within [1, 4].
-	 *
-	 * @param [out] rnd Output array to store rnd values.
-	 */
+	/// Draw floating point pseudo random values from domain.
+	/// This function wraps the integer variant of drawRnd above. But transforms
+	/// the output values into uniformly distributed floats within the range of
+	/// [0, 1).
+	///
+	/// @tparam Size Number of dimensions to draw. Must be within [1, 4].
+	/// @param [out] rnd Output array to store rnd values.
 	template <int Size>
 	OQMC_HOST_DEVICE void drawRnd(float rnd[Size]) const;
 };

--- a/include/oqmc/sobol.h
+++ b/include/oqmc/sobol.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Sobol sampler implementation.
- */
+/// @file
+/// @details Sobol sampler implementation.
 
 #pragma once
 
@@ -94,23 +92,21 @@ void SobolImpl::drawRnd(std::uint32_t rnd[Size]) const
 }
 /// @endcond
 
-/**
- * @brief Owen scrambled sobol sampler.
- * @details The implementation uses an elegant construction by Burley in
- * 'Practical Hash-based Owen Scrambling' for an Owen scrambled Sobol sequence.
- * This also includes performance improvements such as limiting the index to
- * 16 bits, pre-inverting the input and output matrices, and making use of CPU
- * vector intrinsics. You need to select an `OPENQMC_ARCH_TYPE` to make use of
- * the performance from vector intrinsics for a given architecture.
- *
- * This sampler has no cache initialisation cost, it generates all samples on
- * the fly without touching memory. However the cost per draw sample call is
- * computationally higher than other samplers. The quality of Owen scramble
- * sequences often outweigh this cost due to their random error cancellation and
- * incredibly high rate of integration for smooth functions.
- *
- * @ingroup samplers
- */
+/// Owen scrambled sobol sampler.
+/// The implementation uses an elegant construction by Burley in 'Practical
+/// Hash-based Owen Scrambling' for an Owen scrambled Sobol sequence. This also
+/// includes performance improvements such as limiting the index to 16 bits,
+/// pre-inverting the input and output matrices, and making use of CPU vector
+/// intrinsics. You need to select an `OPENQMC_ARCH_TYPE` to make use of the
+/// performance from vector intrinsics for a given architecture.
+///
+/// This sampler has no cache initialisation cost, it generates all samples on
+/// the fly without touching memory. However the cost per draw sample call is
+/// computationally higher than other samplers. The quality of Owen scramble
+/// sequences often outweigh this cost due to their random error cancellation
+/// and incredibly high rate of integration for smooth functions.
+///
+/// @ingroup samplers
 using SobolSampler = SamplerInterface<SobolImpl>;
 
 } // namespace oqmc

--- a/include/oqmc/sobolbn.h
+++ b/include/oqmc/sobolbn.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Sobolbn sampler implementation.
- */
+/// @file
+/// @details Sobolbn sampler implementation.
 
 #pragma once
 
@@ -128,13 +126,11 @@ void SobolBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 }
 /// @endcond
 
-/**
- * @brief Blue noise variant of sobol sampler.
- * @details Same as oqmc::SobolSampler, with additional spatial temporal blue
- * noise dithering between pixels, with progressive pixel sampling support.
- *
- * @ingroup samplers
- */
+/// Blue noise variant of sobol sampler.
+/// Same as oqmc::SobolSampler, with additional spatial temporal blue noise
+/// dithering between pixels, with progressive pixel sampling support.
+///
+/// @ingroup samplers
 using SobolBnSampler = SamplerInterface<SobolBnImpl>;
 
 } // namespace oqmc

--- a/include/oqmc/state.h
+++ b/include/oqmc/state.h
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Sampler state implementation.
- */
+/// @file
+/// @details Sampler state implementation.
 
 #pragma once
 
@@ -18,15 +16,13 @@
 namespace oqmc
 {
 
-/**
- * @brief Generic sampler state type.
- * @details This type is used to represent the state of higher level sampler
- * implementations. The size of the type is carefully handled to make sure it is
- * appropriate to pass-by-value. This allows for efficient functional style use
- * of the higher level API, an important requirement of the API design. This
- * type also provides functionality to mutate the state when building new
- * domains, along with the computation of generic PRNG values.
- */
+/// Generic sampler state type.
+/// This type is used to represent the state of higher level sampler
+/// implementations. The size of the type is carefully handled to make sure it
+/// is appropriate to pass-by-value. This allows for efficient functional style
+/// use of the higher level API, an important requirement of the API design.
+/// This type also provides functionality to mutate the state when building new
+/// domains, along with the computation of generic PRNG values.
 struct State64Bit
 {
 	static constexpr auto maxIndexBitSize = 16;   ///< 2^16 index upper limit.
@@ -38,35 +34,29 @@ struct State64Bit
 	static_assert(spatialEncodeBitSizeX == spatialEncodeBitSizeY,
 	              "Encoding must have equal resolution in x and y");
 
-	/**
-	 * @brief Construct an invalid object.
-	 * @details Create a placeholder object to allocate containers, etc. The
-	 * resulting object is invalid, and you should initialise it by replacing
-	 * the object with another from a parametrised constructor.
-	 */
+	/// Construct an invalid object.
+	/// Create a placeholder object to allocate containers, etc. The resulting
+	/// object is invalid, and you should initialise it by replacing the object
+	/// with another from a parametrised constructor.
 	/*AUTO_DEFINED*/ State64Bit() = default;
 
-	/**
-	 * @brief Parametrised pixel constructor.
-	 * @details Create an object based on the pixel, frame and sample indices.
-	 * Once constructed the state object is valid and ready to use. Pixels are
-	 * correlated by default, use pixelDecorrelate() to decorrelate pixels.
-	 *
-	 * @param [in] x Pixel coordinate on the x axis.
-	 * @param [in] y Pixel coordinate on the y axis.
-	 * @param [in] frame Time index value.
-	 * @param [in] index Sample index. Must be positive.
-	 */
+	/// Parametrised pixel constructor.
+	/// Create an object based on the pixel, frame and sample indices. Once
+	/// constructed the state object is valid and ready to use. Pixels are
+	/// correlated by default, use pixelDecorrelate() to decorrelate pixels.
+	///
+	/// @param [in] x Pixel coordinate on the x axis.
+	/// @param [in] y Pixel coordinate on the y axis.
+	/// @param [in] frame Time index value.
+	/// @param [in] index Sample index. Must be positive.
 	OQMC_HOST_DEVICE State64Bit(int x, int y, int frame, int index);
 
-	/**
-	 * @brief Decorrelate state between pixels.
-	 * @details Using the pixelId, randomise the object state so that
-	 * correlation between pixels is removed. You may want to call this after
-	 * initial construction of which leaves pixels correlated as default.
-	 *
-	 * @return Decorrelated state object.
-	 */
+	/// Decorrelate state between pixels.
+	/// Using the pixelId, randomise the object state so that correlation
+	/// between pixels is removed. You may want to call this after initial
+	/// construction of which leaves pixels correlated as default.
+	///
+	/// @return Decorrelated state object.
 	OQMC_HOST_DEVICE State64Bit pixelDecorrelate() const;
 
 	/// @copydoc oqmc::SamplerInterface::newDomain()
@@ -88,30 +78,26 @@ struct State64Bit
 	std::uint16_t pixelId;   ///< Identifier for pixel position.
 };
 
-/**
- * @brief Compute 16-bit key from index.
- * @details Given a sample index, compute a key value based on the top 16-bits
- * of the integer range. Use computeIndexId() to compute the corrosponding new
- * index to pair with the key.
- *
- * @param [in] index Sample index.
- * @return 16-bit Key value.
- */
+/// Compute 16-bit key from index.
+/// Given a sample index, compute a key value based on the top 16-bits of the
+/// integer range. Use computeIndexId() to compute the corrosponding new index
+/// to pair with the key.
+///
+/// @param [in] index Sample index.
+/// @return 16-bit Key value.
 OQMC_HOST_DEVICE constexpr int computeIndexKey(int index)
 {
 	constexpr auto offset = State64Bit::maxIndexBitSize;
 	return index >> offset;
 }
 
-/**
- * @brief Compute new 16-bit index from index.
- * @details Given a sample index, compute a new index value based on the bottom
- * 16-bits of the integer range. Use computeIndexKey() to compute the
- * corrosponding key value to pair with the new index.
- *
- * @param [in] index Sample index.
- * @return New 16-bit index.
- */
+/// Compute new 16-bit index from index.
+/// Given a sample index, compute a new index value based on the bottom 16-bits
+/// of the integer range. Use computeIndexKey() to compute the corrosponding key
+/// value to pair with the new index.
+///
+/// @param [in] index Sample index.
+/// @return New 16-bit index.
 OQMC_HOST_DEVICE constexpr int computeIndexId(int index)
 {
 	constexpr auto mask = State64Bit::maxIndexSize - 1;
@@ -179,6 +165,8 @@ inline State64Bit State64Bit::newDomainSplit(int key, int size, int index) const
 template <int Size>
 void State64Bit::drawRnd(std::uint32_t rnd[Size]) const
 {
+	static_assert(Size >= 0, "Draw size greater or equal to zero.");
+
 	auto rngState = patternId + sampleId;
 
 	for(int i = 0; i < Size; ++i)

--- a/include/oqmc/stochastic.h
+++ b/include/oqmc/stochastic.h
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details An efficient implementation of progressive multi-jittered (0,2)
- * sequences. This can be used to construct higher level sampler types. The
- * method is based on 'Stochastic Generation of (t, s) Sample Sequences'
- * by Andrew Helmer, et al. As progressive multi-jittered (0,2) XOR tables
- * only produce the first pair of the four dimensions, the second pair is a
- * randomisation of the first.
- */
+/// @file
+/// @details An efficient implementation of progressive multi-jittered (0,2)
+/// sequences. This can be used to construct higher level sampler types. The
+/// method is based on 'Stochastic Generation of (t, s) Sample Sequences' by
+/// Andrew Helmer, et al. As progressive multi-jittered (0,2) XOR tables only
+/// produce the first pair of the four dimensions, the second pair is a
+/// randomisation of the first.
 
 #pragma once
 
@@ -23,16 +21,14 @@
 namespace oqmc
 {
 
-/**
- * @brief Initialise a table with a progressive mult-jittered (0,2) sequence.
- * @details Given a data array and size, compute the corresponding progressive
- * multi-jittered (0,2) sequence value for each element of the array. Each
- * element in the array is a 4 dimensional sample. Number of samples must be
- * larger than zero and no more than 2^16.
- *
- * @param [in] nsamples Size of the table array.
- * @param [out] table Output array of 4 dimensional samples.
- */
+/// Initialise a table with a progressive mult-jittered (0,2) sequence.
+/// Given a data array and size, compute the corresponding progressive
+/// multi-jittered (0,2) sequence value for each element of the array. Each
+/// element in the array is a 4 dimensional sample. Number of samples must be
+/// larger than zero and no more than 2^16.
+///
+/// @param [in] nsamples Size of the table array.
+/// @param [out] table Output array of 4 dimensional samples.
 inline void stochasticPmjInit(int nsamples, std::uint32_t table[][4])
 {
 	constexpr auto maxIndexSize = 0x10000; // 2^16 index upper limit.

--- a/include/oqmc/unused.h
+++ b/include/oqmc/unused.h
@@ -1,15 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
-/**
- * @file
- * @details Defines a macro to declare an expression as potentially unused.
- * This is needed for older versions of C++ without the maybe_unused attribute.
- */
+/// @file
+/// @details Defines a macro to declare an expression as potentially unused.
+/// This is needed for older versions of C++ without the maybe_unused attribute.
 
 #pragma once
 
-/**
- * @brief Macro to declare a symbol unused.
- */
+/// Macro to declare a symbol unused.
 #define OQMC_MAYBE_UNUSED(exp) (void)(exp)


### PR DESCRIPTION
Public header files currently use C style formatting for all Doxygen comments. This might benefit from a more modern and terse style now available in Doxygen and C++.

Update to a more modern style of comments that are easier to author, as well as remove unnecessary 'brief' and 'details' keywords.