### PR TITLE
Add newDomainChain function to sampler interface

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -3,3 +3,4 @@
 *.gif
 *.svg
 *.ipynb
+*.diagrams

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `oqmc::SamplerInterface::newDomainChain()` function is a shorthand for two `oqmc::SamplerInterface::newDomain()`.
+
 ## [0.5.0] - 2024-05-05
 
 ### Added

--- a/include/oqmc/lattice.h
+++ b/include/oqmc/lattice.h
@@ -33,9 +33,9 @@ class LatticeImpl
 	                             const void* cache);
 
 	OQMC_HOST_DEVICE LatticeImpl newDomain(int key) const;
-	OQMC_HOST_DEVICE LatticeImpl newDomainDistrib(int key, int index) const;
 	OQMC_HOST_DEVICE LatticeImpl newDomainSplit(int key, int size,
 	                                            int index) const;
+	OQMC_HOST_DEVICE LatticeImpl newDomainDistrib(int key, int index) const;
 
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
@@ -68,15 +68,15 @@ inline LatticeImpl LatticeImpl::newDomain(int key) const
 	return {state.newDomain(key)};
 }
 
-inline LatticeImpl LatticeImpl::newDomainDistrib(int key, int index) const
-{
-	return {state.newDomainDistrib(key, index)};
-}
-
 inline LatticeImpl LatticeImpl::newDomainSplit(int key, int size,
                                                int index) const
 {
 	return {state.newDomainSplit(key, size, index)};
+}
+
+inline LatticeImpl LatticeImpl::newDomainDistrib(int key, int index) const
+{
+	return {state.newDomainDistrib(key, index)};
 }
 
 template <int Size>

--- a/include/oqmc/latticebn.h
+++ b/include/oqmc/latticebn.h
@@ -42,9 +42,9 @@ class LatticeBnImpl
 	                               const void* cache);
 
 	OQMC_HOST_DEVICE LatticeBnImpl newDomain(int key) const;
-	OQMC_HOST_DEVICE LatticeBnImpl newDomainDistrib(int key, int index) const;
 	OQMC_HOST_DEVICE LatticeBnImpl newDomainSplit(int key, int size,
 	                                              int index) const;
+	OQMC_HOST_DEVICE LatticeBnImpl newDomainDistrib(int key, int index) const;
 
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
@@ -86,15 +86,15 @@ inline LatticeBnImpl LatticeBnImpl::newDomain(int key) const
 	return {state.newDomain(key), cache};
 }
 
-inline LatticeBnImpl LatticeBnImpl::newDomainDistrib(int key, int index) const
-{
-	return {state.newDomainDistrib(key, index), cache};
-}
-
 inline LatticeBnImpl LatticeBnImpl::newDomainSplit(int key, int size,
                                                    int index) const
 {
 	return {state.newDomainSplit(key, size, index), cache};
+}
+
+inline LatticeBnImpl LatticeBnImpl::newDomainDistrib(int key, int index) const
+{
+	return {state.newDomainDistrib(key, index), cache};
 }
 
 template <int Size>

--- a/include/oqmc/pmj.h
+++ b/include/oqmc/pmj.h
@@ -38,8 +38,8 @@ class PmjImpl
 	                         const void* cache);
 
 	OQMC_HOST_DEVICE PmjImpl newDomain(int key) const;
-	OQMC_HOST_DEVICE PmjImpl newDomainDistrib(int key, int index) const;
 	OQMC_HOST_DEVICE PmjImpl newDomainSplit(int key, int size, int index) const;
+	OQMC_HOST_DEVICE PmjImpl newDomainDistrib(int key, int index) const;
 
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
@@ -79,14 +79,14 @@ inline PmjImpl PmjImpl::newDomain(int key) const
 	return {state.newDomain(key), cache};
 }
 
-inline PmjImpl PmjImpl::newDomainDistrib(int key, int index) const
-{
-	return {state.newDomainDistrib(key, index), cache};
-}
-
 inline PmjImpl PmjImpl::newDomainSplit(int key, int size, int index) const
 {
 	return {state.newDomainSplit(key, size, index), cache};
+}
+
+inline PmjImpl PmjImpl::newDomainDistrib(int key, int index) const
+{
+	return {state.newDomainDistrib(key, index), cache};
 }
 
 template <int Size>

--- a/include/oqmc/pmjbn.h
+++ b/include/oqmc/pmjbn.h
@@ -44,9 +44,9 @@ class PmjBnImpl
 	                           const void* cache);
 
 	OQMC_HOST_DEVICE PmjBnImpl newDomain(int key) const;
-	OQMC_HOST_DEVICE PmjBnImpl newDomainDistrib(int key, int index) const;
 	OQMC_HOST_DEVICE PmjBnImpl newDomainSplit(int key, int size,
 	                                          int index) const;
+	OQMC_HOST_DEVICE PmjBnImpl newDomainDistrib(int key, int index) const;
 
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
@@ -90,14 +90,14 @@ inline PmjBnImpl PmjBnImpl::newDomain(int key) const
 	return {state.newDomain(key), cache};
 }
 
-inline PmjBnImpl PmjBnImpl::newDomainDistrib(int key, int index) const
-{
-	return {state.newDomainDistrib(key, index), cache};
-}
-
 inline PmjBnImpl PmjBnImpl::newDomainSplit(int key, int size, int index) const
 {
 	return {state.newDomainSplit(key, size, index), cache};
+}
+
+inline PmjBnImpl PmjBnImpl::newDomainDistrib(int key, int index) const
+{
+	return {state.newDomainDistrib(key, index), cache};
 }
 
 template <int Size>

--- a/include/oqmc/sobol.h
+++ b/include/oqmc/sobol.h
@@ -33,9 +33,9 @@ class SobolImpl
 	                           const void* cache);
 
 	OQMC_HOST_DEVICE SobolImpl newDomain(int key) const;
-	OQMC_HOST_DEVICE SobolImpl newDomainDistrib(int key, int index) const;
 	OQMC_HOST_DEVICE SobolImpl newDomainSplit(int key, int size,
 	                                          int index) const;
+	OQMC_HOST_DEVICE SobolImpl newDomainDistrib(int key, int index) const;
 
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
@@ -68,14 +68,14 @@ inline SobolImpl SobolImpl::newDomain(int key) const
 	return {state.newDomain(key)};
 }
 
-inline SobolImpl SobolImpl::newDomainDistrib(int key, int index) const
-{
-	return {state.newDomainDistrib(key, index)};
-}
-
 inline SobolImpl SobolImpl::newDomainSplit(int key, int size, int index) const
 {
 	return {state.newDomainSplit(key, size, index)};
+}
+
+inline SobolImpl SobolImpl::newDomainDistrib(int key, int index) const
+{
+	return {state.newDomainDistrib(key, index)};
 }
 
 template <int Size>

--- a/include/oqmc/sobolbn.h
+++ b/include/oqmc/sobolbn.h
@@ -42,9 +42,9 @@ class SobolBnImpl
 	                             const void* cache);
 
 	OQMC_HOST_DEVICE SobolBnImpl newDomain(int key) const;
-	OQMC_HOST_DEVICE SobolBnImpl newDomainDistrib(int key, int index) const;
 	OQMC_HOST_DEVICE SobolBnImpl newDomainSplit(int key, int size,
 	                                            int index) const;
+	OQMC_HOST_DEVICE SobolBnImpl newDomainDistrib(int key, int index) const;
 
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
@@ -86,15 +86,15 @@ inline SobolBnImpl SobolBnImpl::newDomain(int key) const
 	return {state.newDomain(key), cache};
 }
 
-inline SobolBnImpl SobolBnImpl::newDomainDistrib(int key, int index) const
-{
-	return {state.newDomainDistrib(key, index), cache};
-}
-
 inline SobolBnImpl SobolBnImpl::newDomainSplit(int key, int size,
                                                int index) const
 {
 	return {state.newDomainSplit(key, size, index), cache};
+}
+
+inline SobolBnImpl SobolBnImpl::newDomainDistrib(int key, int index) const
+{
+	return {state.newDomainDistrib(key, index), cache};
 }
 
 template <int Size>

--- a/include/oqmc/state.h
+++ b/include/oqmc/state.h
@@ -62,12 +62,12 @@ struct State64Bit
 	/// @copydoc oqmc::SamplerInterface::newDomain()
 	OQMC_HOST_DEVICE State64Bit newDomain(int key) const;
 
-	/// @copydoc oqmc::SamplerInterface::newDomainDistrib()
-	OQMC_HOST_DEVICE State64Bit newDomainDistrib(int key, int index) const;
-
 	/// @copydoc oqmc::SamplerInterface::newDomainSplit()
 	OQMC_HOST_DEVICE State64Bit newDomainSplit(int key, int size,
 	                                           int index) const;
+
+	/// @copydoc oqmc::SamplerInterface::newDomainDistrib()
+	OQMC_HOST_DEVICE State64Bit newDomainDistrib(int key, int index) const;
 
 	/// @copydoc oqmc::SamplerInterface::drawRnd()
 	template <int Size>
@@ -135,19 +135,6 @@ inline State64Bit State64Bit::newDomain(int key) const
 	return ret;
 }
 
-inline State64Bit State64Bit::newDomainDistrib(int key, int index) const
-{
-	assert(index >= 0);
-
-	const auto indexKey = computeIndexKey(index);
-	const auto indexId = computeIndexId(index);
-
-	auto ret = newDomain(key).newDomain(indexKey).newDomain(sampleId);
-	ret.sampleId = indexId;
-
-	return ret;
-}
-
 inline State64Bit State64Bit::newDomainSplit(int key, int size, int index) const
 {
 	assert(size > 0);
@@ -157,6 +144,19 @@ inline State64Bit State64Bit::newDomainSplit(int key, int size, int index) const
 	const auto indexId = computeIndexId(sampleId * size + index);
 
 	auto ret = newDomain(key).newDomain(indexKey);
+	ret.sampleId = indexId;
+
+	return ret;
+}
+
+inline State64Bit State64Bit::newDomainDistrib(int key, int index) const
+{
+	assert(index >= 0);
+
+	const auto indexKey = computeIndexKey(index);
+	const auto indexId = computeIndexId(index);
+
+	auto ret = newDomain(key).newDomain(indexKey).newDomain(sampleId);
 	ret.sampleId = indexId;
 
 	return ret;

--- a/src/tools/lib/rng.h
+++ b/src/tools/lib/rng.h
@@ -24,8 +24,8 @@ class RngImpl
 	                         const void* cache);
 
 	OQMC_HOST_DEVICE RngImpl newDomain(int key) const;
-	OQMC_HOST_DEVICE RngImpl newDomainDistrib(int key, int index) const;
 	OQMC_HOST_DEVICE RngImpl newDomainSplit(int key, int size, int index) const;
+	OQMC_HOST_DEVICE RngImpl newDomainDistrib(int key, int index) const;
 
 	template <int Size>
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
@@ -57,14 +57,14 @@ inline RngImpl RngImpl::newDomain(int key) const
 	return {state.newDomain(key)};
 }
 
-inline RngImpl RngImpl::newDomainDistrib(int key, int index) const
-{
-	return {state.newDomainDistrib(key, index)};
-}
-
 inline RngImpl RngImpl::newDomainSplit(int key, int size, int index) const
 {
 	return {state.newDomainSplit(key, size, index)};
+}
+
+inline RngImpl RngImpl::newDomainDistrib(int key, int index) const
+{
+	return {state.newDomainDistrib(key, index)};
 }
 
 template <int Size>

--- a/src/tools/lib/trace.cpp
+++ b/src/tools/lib/trace.cpp
@@ -832,7 +832,7 @@ directLighting(const Session& session, Method method, int numLightSamples,
 				root = directDomain.newDomainDistrib(i, j);
 				break;
 			case Method::Chain:
-				root = directDomain.newDomain(i).newDomain(j);
+				root = directDomain.newDomainChain(i, j);
 				break;
 			};
 


### PR DESCRIPTION
A point was made when gathering feedback that it might be benificial to add a dedicated newDomainChain function to the sampler interface as it is a distinct strategy outlined in the documentation.

Incorporate this feedback and add a newDomainChain function as shorthand for chaining to newDomain calls. Also update some of the related docs so that the use case for this function is clear.