### PR TITLE
Add a newline and whitespace after brief docs

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -36,6 +36,10 @@
   SAVEPLOT=light jupyter execute python/notebooks/performance.ipynb
   SAVEPLOT=dark jupyter execute python/notebooks/performance.ipynb
 
+# build docs
+@docs:
+  doxygen
+
 # remove build and reset
 @clean:
-  rm -rf build
+  rm -rf build html

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ memory allocation, while also allowing inlining for zero-cost abstraction.
 
 ```cpp
 /// Required allocation size of the cache.
+///
 /// Prior to construction of a sampler object, a cache needs to be allocated
 /// and initialised for any given sampler type. This variable is the minimum
 /// required size in bytes of that allocation. The allocation itself is
@@ -307,6 +308,7 @@ static std::size_t oqmc::Sampler::cacheSize;
 
 ```cpp
 /// Initialise the cache allocation.
+///
 /// Prior to construction of a sampler object, a cache needs to be allocated
 /// and initialised for any given sampler type. This function will
 /// initialise that allocation. Once the cache is initialised it may be used
@@ -332,6 +334,7 @@ static void oqmc::Sampler::initialiseCache(void* cache);
 
 ```cpp
 /// Parametrised pixel constructor.
+///
 /// Create an object based on the pixel, frame and sample indices. This also
 /// requires a pre-allocated and initialised cache. Once constructed the
 /// object is valid and ready for use.
@@ -352,6 +355,7 @@ oqmc::Sampler::Sampler(int x, int y, int frame, int index, const void* cache);
 
 ```cpp
 /// Derive a sampler object as a new domain.
+///
 /// The function derives a mutated copy of the current sampler object. This
 /// new object is called a domain. Each domain produces an independent 4
 /// dimensional pattern. Calling the draw* member functions below on the new
@@ -374,6 +378,7 @@ oqmc::Sampler oqmc::Sampler::newDomain(int key) const;
 
 ```cpp
 /// Derive a split sampler object with a local and a global distribution.
+///
 /// Like newDomain, this function derives a mutated copy of the current
 /// sampler object. However, using a technique called splitting, this
 /// domain can have a higher sample rate based on a fixed multiplier.
@@ -402,6 +407,7 @@ oqmc::Sampler oqmc::Sampler::newDomainSplit(int key, int size, int index) const;
 
 ```cpp
 /// Derive a split sampler object with a local distribution.
+///
 /// Like newDomain, this function derives a mutated copy of the current
 /// sampler object. However, using a technique called splitting, this
 /// domain can have a higher sample rate based on an adaptive multiplier.
@@ -429,6 +435,7 @@ oqmc::Sampler oqmc::Sampler::newDomainDistrib(int key, int index) const;
 
 ```cpp
 /// Derive a split sampler object with a global distribution.
+///
 /// Like newDomain, this function derives a mutated copy of the current
 /// sampler object. However, using a technique called splitting, this
 /// domain can have a higher sample rate based on an adaptive multiplier.
@@ -456,6 +463,7 @@ oqmc::Sampler oqmc::Sampler::newDomainChain(int key, int index) const;
 
 ```cpp
 /// Draw integer sample values from domain.
+///
 /// This can compute sample values with up to 4 dimensions for the given
 /// domain. The operation does not change the state of the object, and for a
 /// single domain and index, the result of this function will always be the
@@ -474,6 +482,7 @@ void oqmc::Sampler::drawSample(std::uint32_t sample[Size]) const;
 
 ```cpp
 /// Draw ranged integer sample values from domain.
+///
 /// This function wraps the integer variant of drawSample above. But
 /// transforms the output values into uniformly distributed integers within
 /// the range of [0, range).
@@ -487,6 +496,7 @@ void oqmc::Sampler::drawSample(std::uint32_t range, std::uint32_t sample[Size]) 
 
 ```cpp
 /// Draw floating point sample values from domain.
+///
 /// This function wraps the integer variant of drawSample above. But
 /// transforms the output values into uniformly distributed floats within
 /// the range of [0, 1).
@@ -499,6 +509,7 @@ void oqmc::Sampler::drawSample(float sample[Size]) const;
 
 ```cpp
 /// Draw integer pseudo random values from domain.
+///
 /// This can compute rnd values with up to 4 dimensions for the given
 /// domain. The operation does not change the state of the object, and for a
 /// single domain and index, the result of this function will always be the
@@ -517,6 +528,7 @@ void oqmc::Sampler::drawRnd(std::uint32_t rnd[Size]) const;
 
 ```cpp
 /// Draw ranged integer pseudo random values from domain.
+///
 /// This function wraps the integer variant of drawRnd above. But transforms
 /// the output values into uniformly distributed integers within the range
 /// of [0, range).
@@ -530,6 +542,7 @@ void oqmc::Sampler::drawRnd(std::uint32_t range, std::uint32_t rnd[Size]) const;
 
 ```cpp
 /// Draw floating point pseudo random values from domain.
+///
 /// This function wraps the integer variant of drawRnd above. But transforms
 /// the output values into uniformly distributed floats within the range of
 /// [0, 1).

--- a/include/oqmc/bntables.h
+++ b/include/oqmc/bntables.h
@@ -24,6 +24,7 @@ namespace bntables
 {
 
 /// Return type for table value.
+///
 /// This type composes both a key and a rank value as a pair. These values can
 /// then be used to randomise a sequence.
 struct TableReturnValue
@@ -33,6 +34,7 @@ struct TableReturnValue
 };
 
 /// Lookup value pair from table.
+///
 /// Given an encoded pixel coordinate and an encoded pixel shift, decode the
 /// values and add the shift to the coordinate to compute an index. Using the
 /// index lookup a key and rank value pair from the input tables.

--- a/include/oqmc/encode.h
+++ b/include/oqmc/encode.h
@@ -16,6 +16,7 @@ namespace oqmc
 {
 
 /// Key to encode pixel coordinates.
+///
 /// This structure stores integer coordinate information for each axis of a 3
 /// dimensional array.
 struct EncodeKey
@@ -26,6 +27,7 @@ struct EncodeKey
 };
 
 /// Encode a key value into 16 bits.
+///
 /// Given a coordinate key and a given precision for each axis, encode the
 /// values into a single 16 bit integer value. This can be a lossy operation.
 /// The sum of all precisions must be equal to or less than 16 bits. Decode the
@@ -60,6 +62,7 @@ OQMC_HOST_DEVICE inline std::uint16_t encodeBits16(EncodeKey key)
 }
 
 /// Decode a key value back into a key.
+///
 /// Given a encoded 16 bit integer value and a given precision for each axis,
 /// decode the values into a coordinate key. This can be a lossy operation. The
 /// sum of all precisions must be equal to or less than 16 bits. Encode the

--- a/include/oqmc/float.h
+++ b/include/oqmc/float.h
@@ -19,6 +19,7 @@ constexpr auto floatOneOverUintMax = 2.3283064365386962890625e-10f; ///< 0x1p-32
 constexpr auto floatOneMinusEpsilon = 0.999999940395355224609375f;  ///< max flt
 
 /// Convert an integer into a [0, 1) float.
+///
 /// Given any representable 32 bit unsigned integer, scale the value into a [0,
 /// 1) floating point representation. Note that this operation is lossy and may
 /// not be reversible.

--- a/include/oqmc/lattice.h
+++ b/include/oqmc/lattice.h
@@ -93,6 +93,7 @@ void LatticeImpl::drawRnd(std::uint32_t rnd[Size]) const
 /// @endcond
 
 /// Rank one lattice sampler.
+///
 /// The implementation uses the generator vector from Hickernell et al. in
 /// 'Weighted compound integration rules with higher order convergence for all
 /// N' to construct a 4D lattice. This is then made into a progressive sequence

--- a/include/oqmc/latticebn.h
+++ b/include/oqmc/latticebn.h
@@ -127,6 +127,7 @@ void LatticeBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 /// @endcond
 
 /// Blue noise variant of lattice sampler.
+///
 /// Same as oqmc::LatticeSampler, with additional spatial temporal blue noise
 /// dithering between pixels, with progressive pixel sampling support.
 ///

--- a/include/oqmc/lookup.h
+++ b/include/oqmc/lookup.h
@@ -20,6 +20,7 @@ namespace oqmc
 {
 
 /// Random digit scramble an element in a sequence.
+///
 /// Given a value and a random number, efficiently randomise the value using the
 /// random digit scramble method from Kollig and Keller in 'Efficient
 /// Multidimensional Sampling'. The implementation just requires a single XOR
@@ -36,6 +37,7 @@ randomDigitScramble(std::uint32_t value, std::uint32_t hash)
 }
 
 /// Compute a randomised value from a pre-computed table.
+///
 /// Given an index and a seed, compute an scrambled sequence value. The index
 /// will be shuffled in a manner that is progressive friendly. The value can be
 /// multi-dimensional. For a given sequence, the seed value must be constant.

--- a/include/oqmc/owen.h
+++ b/include/oqmc/owen.h
@@ -35,6 +35,7 @@ namespace oqmc
 {
 
 /// Compute sobol sequence value at an index with reversed bits.
+///
 /// Given a 16 bit index, where the order of bits in the index have been
 /// reversed, compute a sobol sequence value to 16 bits of precision for a given
 /// dimension. Dimensions must be within the range [0, 4).
@@ -253,6 +254,7 @@ OQMC_HOST_DEVICE inline std::uint16_t sobolReversedIndex(std::uint16_t index,
 }
 
 /// Permute an input integer and reverse the bits.
+///
 /// Given an input integer value, perform a Laine and Karras style permutation
 /// and reverse the resulting bits. The permutation can be randomised with a
 /// given seed value. This will be equivalent to an Owen scramble when the input
@@ -271,6 +273,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t scrambleAndReverse(std::uint32_t value,
 }
 
 /// Compute a randomised sobol sequence value.
+///
 /// Given an index and a seed, compute an Owen scrambled sobol sequence value.
 /// The index will be shuffled in a manner that is progressive friendly. The
 /// value can be multi-dimensional. For a given sequence, the seed value must be

--- a/include/oqmc/pcg.h
+++ b/include/oqmc/pcg.h
@@ -26,6 +26,7 @@ namespace pcg
 {
 
 /// State transition function.
+///
 /// Transition state using an LCG to increment the PRNG index along the
 /// sequence. Incrementing the input state can be used to select a new sequence
 /// stream. Note that you may want to use the higher level functionality below.
@@ -40,6 +41,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t stateTransition(std::uint32_t state)
 }
 
 /// Output permutation function.
+///
 /// Output permutation of the PRNG state, resulting in a usable random value
 /// with good statistical properties. This implements the three permutation
 /// operations used in PCG-RXS-M-32. Note you may want to use the higher level
@@ -63,6 +65,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t output(std::uint32_t state)
 }
 
 /// Default initialise the PRNG state.
+///
 /// If given no seed, initialise the PRNG state using a zero value. This must be
 /// done prior to passing the state to other functionality within this file.
 ///
@@ -73,6 +76,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t init()
 }
 
 /// Initialise the PRNG state using a seed value.
+///
 /// If given a seed, initialise the PRNG state using said seed value. This must
 /// be done prior to passing the state to other functionality within this file.
 ///
@@ -84,6 +88,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t init(std::uint32_t seed)
 }
 
 /// Compute a hash value based on an input key.
+///
 /// Given an input key, compute a random hash value. This can be used to
 /// initialise a system or to compute an array of random values in parallel.
 ///
@@ -96,6 +101,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t hash(std::uint32_t key)
 }
 
 /// Compute a random number from the PRNG sequence.
+///
 /// Given a PRNG state, compute the next random number, and iterate the state
 /// for the next value in the sequence. Useful for generating high quality
 /// random numbers when computing them sequentially. The output number will be

--- a/include/oqmc/permute.h
+++ b/include/oqmc/permute.h
@@ -20,6 +20,7 @@ namespace oqmc
 {
 
 /// Laine and Karras style permutation.
+///
 /// Given an unsigned integer number, permute the bits so that lower bits effect
 /// higher bits, but not the other way around. When combined with a reversal of
 /// bits before and after, this forms an efficient hash based owen scrambling
@@ -41,6 +42,7 @@ laineKarrasPermutation(std::uint32_t value, std::uint32_t seed)
 }
 
 /// Reverse input bits and shuffle order.
+///
 /// Given an unsigned integer number, reverse the bit order and then perform a
 /// Laine and Karras style permutation.
 ///
@@ -57,6 +59,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t reverseAndShuffle(std::uint32_t value,
 }
 
 /// Compute a hash based owen scramble.
+///
 /// Given an unsigned integer, use a hash based technique to perform an owen
 /// scramble. This can be used to scramble a value, or to shuffle the order of a
 /// sequence in a progressive friendly manner.

--- a/include/oqmc/pmj.h
+++ b/include/oqmc/pmj.h
@@ -104,6 +104,7 @@ void PmjImpl::drawRnd(std::uint32_t rnd[Size]) const
 /// @endcond
 
 /// Low discrepancy pmj sampler.
+///
 /// The implementation uses the stochastic method described by Helmer et la. in
 /// 'Stochastic Generation of (t, s) Sample Sequences' to efficiently construct
 /// a progressive multi-jittered (0,2) sequence. The first pair of dimensions in

--- a/include/oqmc/pmjbn.h
+++ b/include/oqmc/pmjbn.h
@@ -130,6 +130,7 @@ void PmjBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 /// @endcond
 
 /// Blue noise variant of pmj sampler.
+///
 /// Same as oqmc::PmjSampler, with additional spatial temporal blue noise
 /// dithering between pixels, with progressive pixel sampling support.
 ///

--- a/include/oqmc/range.h
+++ b/include/oqmc/range.h
@@ -16,6 +16,7 @@ namespace oqmc
 {
 
 /// Compute an unsigned integer within 0-bounded half-open range.
+///
 /// Given a range defined using a single unsigned integer, map a full range 32
 /// bit unsigned integer into range.
 ///
@@ -48,6 +49,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t uintToRange(std::uint32_t value,
 }
 
 /// Compute an unsigned integer within half-open range.
+///
 /// Given a range defined using two unsigned integers, map a full range 32 bit
 /// unsigned integer into range. This function is based upon the other uint to
 /// range function and has the same properties.

--- a/include/oqmc/rank1.h
+++ b/include/oqmc/rank1.h
@@ -20,6 +20,7 @@ namespace oqmc
 {
 
 /// Rotate an integer a given distance.
+///
 /// Given a 32 bit unsigned integer value, offset the value a given distance,
 /// and rely on integer overflow for the value to wrap around. When applied to
 /// elements in a lattice, this represents a toroidal shift or rotation, upon
@@ -36,6 +37,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t rotate(std::uint32_t value,
 }
 
 /// Compute a rank 1 lattice value at an index with reversed bits.
+///
 /// Given a 32 bit index, where the order of bits in the index have been
 /// reversed, compute a rank 1 lattice value to 32 bits of precision for a given
 /// dimension. Dimensions must be within the range [0, 4).
@@ -62,6 +64,7 @@ latticeReversedIndex(std::uint32_t index, int dimension)
 }
 
 /// Compute a randomised rank 1 lattice value.
+///
 /// Given an index and a patternId, compute a rank 1 lattice value. The index
 /// will be shuffled in a manner that is progressive friendly. The value can be
 /// multi-dimensional. For a given lattice, the patternId value must be

--- a/include/oqmc/reverse.h
+++ b/include/oqmc/reverse.h
@@ -15,6 +15,7 @@ namespace oqmc
 {
 
 /// Reverse bits of an unsigned 32 bit integer.
+///
 /// Given a 32 bit unsigned integer value, reverse the order of bits so that the
 /// most significant bits become the least significant, and vise versa.
 ///
@@ -41,6 +42,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t reverseBits32(std::uint32_t value)
 }
 
 /// Reverse bits of an unsigned 16 bit integer.
+///
 /// Given a 16 bit unsigned integer value, reverse the order of bits so that the
 /// most significant bits become the least significant, and vise versa.
 ///

--- a/include/oqmc/rotate.h
+++ b/include/oqmc/rotate.h
@@ -15,6 +15,7 @@ namespace oqmc
 {
 
 /// Rotate bits in an integer value.
+///
 /// Offset bits in a 32 bit integer a given distance, while wrapping the bits so
 /// that the value remains the same every distance multiplier of 32.
 ///
@@ -28,6 +29,7 @@ OQMC_HOST_DEVICE constexpr std::uint32_t rotateBits(std::uint32_t value,
 }
 
 /// Rotate bytes in an integer value.
+///
 /// Offset bytes in a 4 byte integer a given distance, while wrapping the bytes
 /// so that the value remains the same every distance multiplier of 4.
 ///

--- a/include/oqmc/sampler.h
+++ b/include/oqmc/sampler.h
@@ -16,6 +16,7 @@
 
 /// @defgroup samplers Sampler API
 /// Higher level sampler API and sampler types.
+///
 /// This module outlines the higher level sampler API, as well as each availble
 /// sampler type. Sampler type implementations are non-public, and all
 /// functionality is accessible via the SamplerInterface. There are two variants
@@ -71,6 +72,7 @@ namespace oqmc
 {
 
 /// Public sampler API.
+///
 /// This is a sampler interface that defines a generic API for all sampler
 /// types. The interface is composed of an internal implementation, meaning only
 /// this public API is exposed to calling code.
@@ -120,6 +122,7 @@ class SamplerInterface
 
   public:
 	/// Required allocation size of the cache.
+	///
 	/// Prior to construction of a sampler object, a cache needs to be allocated
 	/// and initialised for any given sampler type. This variable is the minimum
 	/// required size in bytes of that allocation. The allocation itself is
@@ -128,6 +131,7 @@ class SamplerInterface
 	static constexpr std::size_t cacheSize = Impl::cacheSize;
 
 	/// Initialise the cache allocation.
+	///
 	/// Prior to construction of a sampler object, a cache needs to be allocated
 	/// and initialised for any given sampler type. This function will
 	/// initialise that allocation. Once the cache is initialised it may be used
@@ -151,12 +155,14 @@ class SamplerInterface
 	static void initialiseCache(void* cache);
 
 	/// Construct an invalid sampler object.
+	///
 	/// Create a placeholder object to allocate containers, etc. The resulting
 	/// object is invalid, and you should initialise it by replacing the object
 	/// with another from a parametrised constructor.
 	/*AUTO_DEFINED*/ SamplerInterface() = default;
 
 	/// Parametrised pixel constructor.
+	///
 	/// Create an object based on the pixel, frame and sample indices. This also
 	/// requires a pre-allocated and initialised cache. Once constructed the
 	/// object is valid and ready for use.
@@ -176,6 +182,7 @@ class SamplerInterface
 	                                  const void* cache);
 
 	/// Derive a sampler object as a new domain.
+	///
 	/// The function derives a mutated copy of the current sampler object. This
 	/// new object is called a domain. Each domain produces an independent 4
 	/// dimensional pattern. Calling the draw* member functions below on the new
@@ -196,6 +203,7 @@ class SamplerInterface
 	OQMC_HOST_DEVICE SamplerInterface newDomain(int key) const;
 
 	/// Derive a split sampler object with a local and a global distribution.
+	///
 	/// Like newDomain, this function derives a mutated copy of the current
 	/// sampler object. However, using a technique called splitting, this
 	/// domain can have a higher sample rate based on a fixed multiplier.
@@ -223,6 +231,7 @@ class SamplerInterface
 	                                                 int index) const;
 
 	/// Derive a split sampler object with a local distribution.
+	///
 	/// Like newDomain, this function derives a mutated copy of the current
 	/// sampler object. However, using a technique called splitting, this
 	/// domain can have a higher sample rate based on an adaptive multiplier.
@@ -249,6 +258,7 @@ class SamplerInterface
 	                                                   int index) const;
 
 	/// Derive a split sampler object with a global distribution.
+	///
 	/// Like newDomain, this function derives a mutated copy of the current
 	/// sampler object. However, using a technique called splitting, this
 	/// domain can have a higher sample rate based on an adaptive multiplier.
@@ -274,6 +284,7 @@ class SamplerInterface
 	OQMC_HOST_DEVICE SamplerInterface newDomainChain(int key, int index) const;
 
 	/// Draw integer sample values from domain.
+	///
 	/// This can compute sample values with up to 4 dimensions for the given
 	/// domain. The operation does not change the state of the object, and for a
 	/// single domain and index, the result of this function will always be the
@@ -290,6 +301,7 @@ class SamplerInterface
 	OQMC_HOST_DEVICE void drawSample(std::uint32_t sample[Size]) const;
 
 	/// Draw ranged integer sample values from domain.
+	///
 	/// This function wraps the integer variant of drawSample above. But
 	/// transforms the output values into uniformly distributed integers within
 	/// the range of [0, range).
@@ -302,6 +314,7 @@ class SamplerInterface
 	                                 std::uint32_t sample[Size]) const;
 
 	/// Draw floating point sample values from domain.
+	///
 	/// This function wraps the integer variant of drawSample above. But
 	/// transforms the output values into uniformly distributed floats within
 	/// the range of [0, 1).
@@ -312,6 +325,7 @@ class SamplerInterface
 	OQMC_HOST_DEVICE void drawSample(float sample[Size]) const;
 
 	/// Draw integer pseudo random values from domain.
+	///
 	/// This can compute rnd values with up to 4 dimensions for the given
 	/// domain. The operation does not change the state of the object, and for a
 	/// single domain and index, the result of this function will always be the
@@ -328,6 +342,7 @@ class SamplerInterface
 	OQMC_HOST_DEVICE void drawRnd(std::uint32_t rnd[Size]) const;
 
 	/// Draw ranged integer pseudo random values from domain.
+	///
 	/// This function wraps the integer variant of drawRnd above. But transforms
 	/// the output values into uniformly distributed integers within the range
 	/// of [0, range).
@@ -340,6 +355,7 @@ class SamplerInterface
 	                              std::uint32_t rnd[Size]) const;
 
 	/// Draw floating point pseudo random values from domain.
+	///
 	/// This function wraps the integer variant of drawRnd above. But transforms
 	/// the output values into uniformly distributed floats within the range of
 	/// [0, 1).

--- a/include/oqmc/sobol.h
+++ b/include/oqmc/sobol.h
@@ -93,6 +93,7 @@ void SobolImpl::drawRnd(std::uint32_t rnd[Size]) const
 /// @endcond
 
 /// Owen scrambled sobol sampler.
+///
 /// The implementation uses an elegant construction by Burley in 'Practical
 /// Hash-based Owen Scrambling' for an Owen scrambled Sobol sequence. This also
 /// includes performance improvements such as limiting the index to 16 bits,

--- a/include/oqmc/sobolbn.h
+++ b/include/oqmc/sobolbn.h
@@ -127,6 +127,7 @@ void SobolBnImpl::drawRnd(std::uint32_t rnd[Size]) const
 /// @endcond
 
 /// Blue noise variant of sobol sampler.
+///
 /// Same as oqmc::SobolSampler, with additional spatial temporal blue noise
 /// dithering between pixels, with progressive pixel sampling support.
 ///

--- a/include/oqmc/state.h
+++ b/include/oqmc/state.h
@@ -17,6 +17,7 @@ namespace oqmc
 {
 
 /// Generic sampler state type.
+///
 /// This type is used to represent the state of higher level sampler
 /// implementations. The size of the type is carefully handled to make sure it
 /// is appropriate to pass-by-value. This allows for efficient functional style
@@ -35,12 +36,14 @@ struct State64Bit
 	              "Encoding must have equal resolution in x and y");
 
 	/// Construct an invalid object.
+	///
 	/// Create a placeholder object to allocate containers, etc. The resulting
 	/// object is invalid, and you should initialise it by replacing the object
 	/// with another from a parametrised constructor.
 	/*AUTO_DEFINED*/ State64Bit() = default;
 
 	/// Parametrised pixel constructor.
+	///
 	/// Create an object based on the pixel, frame and sample indices. Once
 	/// constructed the state object is valid and ready to use. Pixels are
 	/// correlated by default, use pixelDecorrelate() to decorrelate pixels.
@@ -52,6 +55,7 @@ struct State64Bit
 	OQMC_HOST_DEVICE State64Bit(int x, int y, int frame, int index);
 
 	/// Decorrelate state between pixels.
+	///
 	/// Using the pixelId, randomise the object state so that correlation
 	/// between pixels is removed. You may want to call this after initial
 	/// construction of which leaves pixels correlated as default.
@@ -79,6 +83,7 @@ struct State64Bit
 };
 
 /// Compute 16-bit key from index.
+///
 /// Given a sample index, compute a key value based on the top 16-bits of the
 /// integer range. Use computeIndexId() to compute the corrosponding new index
 /// to pair with the key.
@@ -92,6 +97,7 @@ OQMC_HOST_DEVICE constexpr int computeIndexKey(int index)
 }
 
 /// Compute new 16-bit index from index.
+///
 /// Given a sample index, compute a new index value based on the bottom 16-bits
 /// of the integer range. Use computeIndexKey() to compute the corrosponding key
 /// value to pair with the new index.

--- a/include/oqmc/stochastic.h
+++ b/include/oqmc/stochastic.h
@@ -22,6 +22,7 @@ namespace oqmc
 {
 
 /// Initialise a table with a progressive mult-jittered (0,2) sequence.
+///
 /// Given a data array and size, compute the corresponding progressive
 /// multi-jittered (0,2) sequence value for each element of the array. Each
 /// element in the array is a 4 dimensional sample. Number of samples must be


### PR DESCRIPTION
In feedback it was suggested that whitespace between the brief and the body would make the doxygen style docs clearer to read. Currently, there is no whitespace.

Add a simple whitespace after the brief across the public API. Also add a just recipe to build the docs, and make sure the clean recipe removes the html directory.