### PR TITLE
Add support for running a dev env using Docker

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -42,4 +42,4 @@
 
 # remove build and reset
 @clean:
-  rm -rf build html
+  rm -rf build html result

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nixos/nix:2.21.4
+
+COPY . /tmp/build
+WORKDIR /tmp/build
+
+RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf && nix develop
+
+ENTRYPOINT ["nix", "develop"]

--- a/README.md
+++ b/README.md
@@ -1620,6 +1620,23 @@ notebooks, there is a dedicated development environment:
 nix develop .#notebook
 ```
 
+### Docker development environment
+
+On systems without Nix, a Dockerfile is also provided to build a development
+environment as a container. First you need to build the container:
+
+
+```bash
+docker build -t openqmc-develop .
+```
+
+This might take some time as it pulls in the dependencies. But once it is
+complete the environment can then be efficiently run using:
+
+```bash
+docker run --rm -it openqmc-develop
+```
+
 ## Related projects
 
 Here are details on other related projects, and how OpenQMC is different. If


### PR DESCRIPTION
It is common practice in industry to use Docker as a development env, and it is more likely that a developer will have Docker installed in comparison to Nix.

Provide an alternative workflow for users without Nix, and that are more comfortable with Docker. This is simply a wrapper around the Nix workflow and does not duplicate the maintenance cost. Probably further work could be done in this area. Might be good to capture feedback first.