### PR TITLE
Update docker dev env to use docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM nixos/nix:2.21.4
-
-COPY . /tmp/build
-WORKDIR /tmp/build
-
-RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf && nix develop
-
-ENTRYPOINT ["nix", "develop"]

--- a/README.md
+++ b/README.md
@@ -1622,19 +1622,18 @@ nix develop .#notebook
 
 ### Docker development environment
 
-On systems without Nix, a Dockerfile is also provided to build a development
-environment as a container. First you need to build the container:
-
+On systems without Nix, a Docker solution is also provided to run a development
+environment as a service. This is done using Docker Compose:
 
 ```bash
-docker build -t openqmc-develop .
+docker compose run --rm develop
 ```
 
-This might take some time as it pulls in the dependencies. But once it is
-complete the environment can then be efficiently run using:
+From within the service container you can also install other tools as required
+from Nixpkgs, such as an editor like Helix:
 
 ```bash
-docker run --rm -it openqmc-develop
+nix profile install nixpkgs#helix
 ```
 
 ## Related projects

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the OpenQMC Project.
+
+services:
+  develop:
+    image: nixpkgs/nix-flakes:nixos-24.05
+    command: nix develop
+    working_dir: /tmp/src
+    volumes:
+      - .:/tmp/src


### PR DESCRIPTION
Current Docker development workflow is not very usable as it copies the source code rather than mirror it. As a result changes externally are not represented once the container image is built.

Instead, switch to using Docker Compose to mount the source code as a volume. This allows the code to stay in sync. Also update the docs.