### PR TITLE
Update CHANGELOG with new release note on docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `oqmc::SamplerInterface::newDomainChain()` function is a shorthand for two `oqmc::SamplerInterface::newDomain()`.
+- Support and documentation for using Docker Compose to set up a development environment.
 
 ## [0.5.0] - 2024-05-05
 


### PR DESCRIPTION
Add a missing release note to the CHANGELOG file on the added support for docker based development environments.