### PR TITLE
Add breadcrumbs to track source of sobol matrices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the OpenQMC Project.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 
 # Create the project and set the version
 

--- a/README.md
+++ b/README.md
@@ -1376,9 +1376,27 @@ nix profile install nixpkgs#helix
 Alternatively you can build the project without using a provided development
 environment using a local compiler. This should work just fine on most systems.
 
+### Navigation
+
+The project has a simple layout. As the library is header only the library
+source code is under the include directory. A large proportion of the project
+code is also the tooling and testing. This is found under the src directory.
+
+The directories are:
+
+- `cmake`: CMake examples for adding OpenQMC as a dependency.
+- `doxygen`: Extra static pages for Doxygen API documentation site.
+- `images`: Documentation images generated using the tools and notebooks.
+- `include`: OpenQMC library source code.
+- `python`: Jupyter notebooks and Python wrapper for tooling.
+- `scripts`: Utility scripts for command line and CI usage.
+- `src/tests`: Unit and statistical hypothesis testing.
+- `src/tools`: Project tooling for analysis and offline optimisation.
+- `tsc`: Meeting notes and project process documentation.
+
 ### Dependencies
 
-The tools and tests have dependencies on external projects. If these are already
+Tools and tests have dependencies on external libraries. If these are already
 installed on the system they can be found automatically, such as when using one
 of the development environments. If a dependency isn't installed, then it will
 be downloaded and compiled along with the project.

--- a/include/oqmc/bntables.h
+++ b/include/oqmc/bntables.h
@@ -74,6 +74,9 @@ constexpr auto size = 1 << (xBits + yBits + zBits); ///< 2^16 table size.
 static_assert(xBits == yBits,
               "Optimisation tables have equal resolution in x and y");
 
+// Following optimised blue noise randomisation values were generated using the
+// optimise cli tool found in the source file src/tools/lib/optimise.cpp.
+
 namespace pmj
 {
 

--- a/include/oqmc/owen.h
+++ b/include/oqmc/owen.h
@@ -54,6 +54,10 @@ OQMC_HOST_DEVICE inline std::uint16_t sobolReversedIndex(std::uint16_t index,
 		return reverseBits16(index);
 	}
 
+	// Following matrices were produced using the matrices cli tool found in the
+	// source file src/tools/cli/matrices.cpp. This in turn uses matrices that
+	// were copied from MIT licensed code written by Leonhard Gruenschloss.
+
 	// clang-format off
 	constexpr std::uint16_t masks[16] = {
 		0b0000000000000001,

--- a/include/oqmc/rank1.h
+++ b/include/oqmc/rank1.h
@@ -51,6 +51,9 @@ latticeReversedIndex(std::uint32_t index, int dimension)
 	assert(dimension >= 0);
 	assert(dimension <= 3);
 
+	// Following Rank1 lattice numbers were taken from the orignal publication
+	// listed at the top of this file.
+
 	// clang-format off
 	constexpr int lattice[4] = {
 		1,

--- a/src/tools/cli/matrices.cpp
+++ b/src/tools/cli/matrices.cpp
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
+// This file is used to compile a cli tool that will transform and print a
+// subset of the matrices below into an optimal format for the main library.
+// Resulting output is inlined into a header file include/oqmc/owen.h.
+//
+// Matrices in the source code below were copied from the source code provided
+// by Leonhard Gruenschloss at https://github.com/lgruen/sobol. These were in
+// turn based on work by S. Joe and F. Y. Kuo in 'Constructing Sobol sequences
+// with better two-dimensional projections'.
+
 // Copyright (c) 2012 Leonhard Gruenschloss (leonhard@gruenschloss.org)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/tools/lib/optimise.cpp
+++ b/src/tools/lib/optimise.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenQMC Project.
 
+// This file is used to compile a cli tool that will output optimised blue noise
+// numbers to then construct multiple blue noise variants of base sampler types.
+// Resulting output is inlined into a header file include/oqmc/bntables.h.
+
 #include "optimise.h"
 
 #include "../../shapes.h"


### PR DESCRIPTION
It would be helpful if the code provided a breadcrumb trail to track the source of sobol matrices and other similar data that is inlined to the code. This will then aid and allow review of the project sources.

Add the comments to track forward and backward where the sobol matrices, rank1 lattice numbers, and optimised blue noise numbers are sourced from and used. Also provide a navigation sections to the docs.