### PR TITLE
Add an SVG version of the logo to the images folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SVG formated version of the logo to the images folder.
+
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [0.7.0] - 2025-03-15
 
 ### Added

--- a/images/openqmc-logo.svg
+++ b/images/openqmc-logo.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa8ef29b1cceba3bb3c00828d6b5e4c4e4a35682ecaceaa64a87642f0b8d57aa
+size 208836


### PR DESCRIPTION
It would be helpful to have the logo in an SVG format for marketing and other standard use cases on websites. Although there is no original version of this logo as a vector graphic.

Run the raster image of the logo through a vectorizer and save out the result as an SVG.