### PR TITLE
Update the org name to AcademySoftwareFoundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SVG formated version of the logo to the images folder.
 
 ### Changed
+
+- Update org name to AcademySoftwareFoundation.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,6 +1,6 @@
 @software{Bainbridge_OpenQMC_2022,
 author = {Bainbridge, Josh},
 year = {2022},
-url = {https://github.com/framestore/openqmc},
+url = {https://github.com/AcademySoftwareFoundation/openqmc},
 title = {OpenQMC sampling library for graphics applications}
 }

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
   </picture>
 </p>
 
-[![License](https://img.shields.io/badge/License-Apache--2.0-informational)](https://github.com/framestore/openqmc/blob/main/LICENSE)
-[![Release](https://img.shields.io/github/v/release/framestore/openqmc?label=Release)](https://github.com/framestore/openqmc/releases/latest)
+[![License](https://img.shields.io/badge/License-Apache--2.0-informational)](https://github.com/AcademySoftwareFoundation/openqmc/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/AcademySoftwareFoundation/openqmc?label=Release)](https://github.com/AcademySoftwareFoundation/openqmc/releases/latest)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/joshbainbridge/c64d4efeaa4f0760255cc54cdadce85c/raw/test.json)
-[![CI Pipeline](https://github.com/framestore/openqmc/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/framestore/openqmc/actions/workflows/ci-pipeline.yml)
+[![CI Pipeline](https://github.com/AcademySoftwareFoundation/openqmc/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/openqmc/actions/workflows/ci-pipeline.yml)
 
 OpenQMC is a library for sampling high quality Quasi-Monte Carlo (QMC) points
 and generating pseudo random numbers. Designed for graphics applications,
@@ -158,7 +158,7 @@ platforms. The flake can also be used to load a reproducible [developer
 environment](#nix-development-environment). Install the package with:
 
 ```bash
-nix profile install github:framestore/openqmc
+nix profile install github:AcademySoftwareFoundation/openqmc
 ```
 
 ### Cloning the source
@@ -167,7 +167,7 @@ Alternatively for installing from source, you can download a release from the
 site, or clone the project with:
 
 ```bash
-git clone git@github.com:framestore/openqmc.git
+git clone git@github.com:AcademySoftwareFoundation/openqmc.git
 ```
 
 ## Adding to your project
@@ -1681,7 +1681,7 @@ please see the following pages:
   as members of the larger community.
 
 If instead you want to submit an issue or a request, report it by creating a
-new GitHub [issue](https://github.com/framestore/openqmc/issues).
+new GitHub [issue](https://github.com/AcademySoftwareFoundation/openqmc/issues).
 
 [^1]: Brent Burley. 2020.  
 Practical Hash-based Owen Scrambling. JCGT.  

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,7 +5,7 @@ There are a few ways to connect with the OpenQMC project:
 - Add yourself to the TBD mailing list.
 - Start a thread on the TBD forums.
 - Join the TBD Slack channel.
-- Create a new GitHub [issue](https://github.com/framestore/openqmc/issues).
+- Create a new GitHub [issue](https://github.com/AcademySoftwareFoundation/openqmc/issues).
 
 ## How to ask for help
 
@@ -13,7 +13,7 @@ If you have trouble installing, building, or using OpenQMC, but there's not yet 
 
 ## How to report a bug or request an enhancement
 
-OpenQMC manages bug and enhancement using its [issue](https://github.com/framestore/openqmc/issues) tracker. The issue template will guide you on making an effective report.
+OpenQMC manages bug and enhancement using its [issue](https://github.com/AcademySoftwareFoundation/openqmc/issues) tracker. The issue template will guide you on making an effective report.
 
 ## How to report a security vulnerability
 


### PR DESCRIPTION
In preperation for the move to ASWF as a member project, the repo needs to update references to the GitHub organisation.

Perform an initial search and replace, updating the organisation name to match the destination of the repo under AcademySoftwareFoundation.