### PR TITLE
Start using Nix for consistency on CI

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -12,35 +12,27 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-      - run: pip install ruff==0.14.1
-      - run: pip install ty==0.0.1a23
-      - run: scripts/check-format.sh
+      - uses: cachix/install-nix-action@v25
+      - run: nix develop -ic scripts/check-format.sh
 
   check-static-analyzer:
     name: Check static analysis
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-      - run: pip install ruff==0.14.1
-      - run: pip install ty==0.0.1a23
-      - run: cmake --preset unix
-      - run: scripts/check-lint.sh
+      - uses: cachix/install-nix-action@v25
+      - run: nix develop -ic cmake --preset unix
+      - run: nix develop -ic scripts/check-lint.sh
 
   check-documentation:
     name: Check documentation
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
       - run: curl -L -O https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.4.0/doxygen-awesome.css
       - run: curl -L -O https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.4.0/doxygen-awesome-sidebar-only.css
-      - run: sudo apt-get update && sudo apt-get install doxygen graphviz
-      - run: scripts/check-documentation.sh
+      - run: nix develop -ic scripts/check-documentation.sh
 
   install:
     name: Install library

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         } {
           name = "devshell";
           packages = [
-            pkgs.llvmPackages_18.clang-tools # matching version on GitHub runner
+            pkgs.clang-tools
             pkgs.cmakeCurses
             pkgs.ninja
             pkgs.just

--- a/src/tools/lib/optimise.cpp
+++ b/src/tools/lib/optimise.cpp
@@ -908,7 +908,7 @@ struct Pmj
 {
 	OQMC_HOST_DEVICE static void* initialiseCache()
 	{
-		std::uint32_t(*samples)[4];
+		std::uint32_t (*samples)[4];
 		OQMC_ALLOCATE(&samples, oqmc::State64Bit::maxIndexSize);
 
 		oqmc::stochasticPmjInit(oqmc::State64Bit::maxIndexSize, samples);
@@ -924,7 +924,7 @@ struct Pmj
 	OQMC_HOST_DEVICE static void sample(int index, std::uint32_t hash,
 	                                    const void* cache, std::uint32_t out[2])
 	{
-		auto samples = static_cast<const std::uint32_t(*)[4]>(cache);
+		auto samples = static_cast<const std::uint32_t (*)[4]>(cache);
 		oqmc::shuffledScrambledLookup<4, 2>(index, hash, samples, out);
 	}
 };


### PR DESCRIPTION
After initial exploration done on 9756110 the conclusion was that
there were a few blocker preventing us from effectively using Nix on the
GitHub CI. Re-visiting this after recent updates, it is now much more
viable to leverage Nix in the CI for consistent testing.

This commit does not deploy Nix for all CI build stages, but it does for
all test jobs. This allows us to drive the clang-tools version from the
locked Nix environment, as opposed to the variable versions used on the
GitHub runners. We then get a bit more compiler coverage on the later
jobs, although this might also get moved over in time.

Updating clang-tools also meant that some tests failed. As a result,
this commit also updates the code to resolve the failing tests.