### PR TITLE
Add ty check for Python type checking

### DIFF
--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -10,6 +10,5 @@ git ls-files | grep -E '\.(cpp)$' | grep -v -E '^cmake/examples/' | xargs clang-
 ruff --version
 git ls-files | grep -E '\.(py)$' | xargs ruff check --quiet
 
-# TODO: enable ty Python checks once Python dependencies can be resolved on CI.
-# ty --version
-# git ls-files | grep -E '\.(py)$' | xargs ty check --quiet
+ty --version
+git ls-files | grep -E '\.(py)$' | xargs ty check --quiet


### PR DESCRIPTION
There is a TODO to enable ty from Astral for type checking on the CI. This wasn't feasible before as the same version was not availble via the CI runners. Since switching the runners over to Nix, that has now changed.

Uncomment the lines that enable ty checks on the CI script.