### PR TITLE
Add Codespaces support and Git LFS to Nix Flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,16 @@ nix profile install nixpkgs#helix
 Alternatively you can build the project without using a provided development
 environment using a local compiler. This should work just fine on most systems.
 
+### GitHub Codespaces
+
+You can also use [GitHub Codespaces](https://github.com/features/codespaces) to
+develop the project. Once a Codespace is running, use the same Docker Compose
+command from the integrated terminal to enter the development environment:
+
+```bash
+docker compose run --rm --service-ports develop
+```
+
 ### Navigation
 
 The project has a simple layout. As the library is header only the library

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             pkgs.just
             pkgs.curl
             pkgs.git
+            pkgs.git-lfs
             pkgs.ty
             pkgs.ruff
             pkgs.doxygen
@@ -54,6 +55,7 @@
           shellHook = ''
             export TOOLSPATH=$PWD/build/src/tools/lib
             export PYTHONPATH=$PYTHONPATH:$PWD/python
+            git lfs install > /dev/null
           '';
         };
       }


### PR DESCRIPTION
The Docker development environment does not persist user configuration between sessions. This means Git LFS hooks are not configured inside the container, causing LFS files to appear modified.

Add git-lfs to the flake packages and run git lfs install in the shell hook so that LFS is configured automatically. Add a GitHub Codespaces section to the README directing users to the Docker Compose workflow.