### PR TITLE
Efficient uniform int-to-float conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Improve quality of uniform float distribution in `oqmc::uintToFloat`.
+
 ### Security
 
 ## [0.7.1] - 2025-08-23

--- a/include/oqmc/float.h
+++ b/include/oqmc/float.h
@@ -9,7 +9,6 @@
 
 #include "gpu.h"
 
-#include <cmath>
 #include <cstdint>
 
 /// @defgroup utilities Utilities API
@@ -32,8 +31,7 @@
 namespace oqmc
 {
 
-constexpr auto floatOneOverUintMax = 2.3283064365386962890625e-10f; ///< 0x1p-32
-constexpr auto floatOneMinusEpsilon = 0.999999940395355224609375f;  ///< max flt
+constexpr auto floatOneOverTwoPower32 = 1.0f / (1ull << 32); ///< 0x1p-32
 
 /// Convert an integer into a [0, 1) float.
 ///
@@ -46,24 +44,116 @@ constexpr auto floatOneMinusEpsilon = 0.999999940395355224609375f;  ///< max flt
 /// @return Floating point number within the range [0, 1).
 OQMC_HOST_DEVICE inline float uintToFloat(std::uint32_t value)
 {
-	// This method is inspired by the method used by Matt Pharr in PBRT v4. It
-	// has the undesirable property of floating point values rounding up to the
-	// nearest representable number to reduce error. This gives the potential
-	// for an output equal to one, requiring a min operation. However, this was
-	// considered the best tradeoff when compared to other methods.
+	// There are various methods for converting an integer to a float, each with
+	// a different balance of speed, quality and complexity.
 
+	// Option 1: Default Conversion and Clamp Maximum
+	//
+	// A simple method is to cast the integer to a floating point
+	// type, using the default runtime rounding mode (round nearest), and then
+	// multiply by the reciprocal of the (exclusive) integer maximum (1/2^32).
+	// This method is fast and retains a lot of precision, but has the
+	// undesirable property of floating point values rounding up to the nearest
+	// representable number to reduce error. This gives the potential for an
+	// output equal to one, requiring a min operation. It also means the
+	// probability density of representable values is not uniform. For example,
+	// output 0.5 is 50% more likely than the next value.
+
+	// Option 2: Truncate Precision and Default Conversion
+	//
 	// Marc Reynolds gives an option where 8 bits of precision is first removed
+	// prior to division:
 	// (http://marc-b-reynolds.github.io/distribution/2017/01/17/DenseFloat.html)
-	// prior to division. This removes the need for any min operations, but also
-	// looses us a good amount of precision sub one half.
+	// This removes the need for any min operations, but also loses precision
+	// below one half; significant precision is lost for small values.
 
-	// An alternative algorithm using a clz operation is detailed in Section 2.1
-	// of 'Quasi-Monte Carlo Algorithms (not only) for Graphics Software'. This
-	// optimally maps the unsinged integer bits to the floating point exponent
-	// and mantissa. However, after benchmarking this alternative method the
-	// cost when drawing samples was a 2x time increase for some samplers.
+	// Option 3: Count Leading Zeros and Bitwise Manipulation
+	//
+	// A high-quality reference method is detailed in Section 2.1 of
+	// 'Quasi-Monte Carlo Algorithms (not only) for Graphics Software' by
+	// Keller, Wächter and Binder. This remaps the integer bits to the floating
+	// point exponent and mantissa to provide optimal uniform probability
+	// density. The computational cost however is high, due to instructions
+	// for counting leading zeroes and manipulating the mantissa and exponent
+	// bit patterns directly. It also uses a bitwise cast that can impact
+	// optimiser analysis on some platforms. See a97ad21 for details.
 
-	return std::fmin(value * floatOneOverUintMax, floatOneMinusEpsilon);
+	// Option 4: Adjust Integer and Default Conversion (Current Implementation)
+	//
+	// The following implementation provides results identical to the option 3,
+	// while using a simpler approach that is more efficient on common
+	// architectures.
+	//
+	// The reference method generates values equivalent to modifying the runtime
+	// environment to round down, and then performing the conversion and scale:
+	//		`std::fesetround(FE_DOWNWARD);`
+	// 		`return static_cast<float>(value) * floatOneOverTwoPower32;`
+	//
+	// Unfortunately, modifying the runtime rounding mode is often expensive,
+	// prohibited or ignored (see #pragma STDC FENV_ACCESS). It also affects
+	// subsequent operations unless the previous state is restored.
+
+	// However, it is possible to achieve the same effect by adjusting the
+	// integer so that its conversion to floating point will always round down
+	// with the default runtime mode (round nearest). This retains the optimal
+	// uniform probability density at a lower computational cost.
+
+	// When an integer is converted to floating point, the hardware identifies
+	// the position of the leading one bit. The mantissa stores the following 23
+	// bits, while the exponent encodes the position of that leading one.
+	// The next three bits (guard, round, and sticky) govern the rounding
+	// decision. The sticky bit represents the logical OR of all bits shifted
+	// out beyond the round bit.
+
+	// For example, consider a 32-bit input integer with three leading zeroes:
+	//
+	//        <-----------32 bits------------>
+	// Input: 0001mmmmmmmmmmmmmmmmmmmmmmmgrsss
+	//           |<-------23 bits------->|
+	//			 1                       g
+	// Key:
+	// 		0 = leading zeros
+	//		1 = leading one
+	//		m = mantissa
+	//		g = guard
+	// 		r = round
+	//		s = sticky
+	//
+	// To force rounding down during float conversion, it is both necessary and
+	// sufficient to clear the guard bit.
+	//
+	// Fortunately, the guard bit (when present) is always located 24 bits
+	// to the right of the leading one. This allows it to be cleared
+	// efficiently without explicitly determining the position of either bit.
+	// The integer is shifted right by 24 bits to generate a mask that clears
+	// the guard bit and leaves the mantissa unmodified.
+
+	// For example, with three leading zeroes the following bit patterns
+	// are used:
+	//
+	// Input : 0001mmmm mmmmmmmm mmmmmmmm mmmgrsss
+	// Mask  : 00000000 00000000 00000000 0001mmmm  	mask = input >> 24
+	// Safe  : 0001mmmm mmmmmmmm mmmmmmmm mmm0????  	safe = input & ~mask
+	//                                       ^
+	//                              guard bit cleared
+	//
+	// The round and sticky bits are left undefined but do not affect the
+	// outcome. With the guard bit cleared, the adjusted integer lies
+	// strictly below the rounding tie-break, ensuring that both the round
+	// and sticky bits are ignored.
+	//
+	// For inputs less than 2^24, the conversion to floating point is exact.
+	// In this case, the mask evaluates to zero and the operation has no effect.
+
+	// On common architectures this reduces to two or three instructions.
+	// For example, ARMv8 requires two instructions: one that combines the
+	// shift-not-and operations, and one for the conversion to float with
+	// free scale by power-of-two constant.
+
+	const auto mask = value >> 24;
+	const auto safe = value & ~mask;
+
+	return static_cast<float>(safe) * floatOneOverTwoPower32;
 }
 
 } // namespace oqmc

--- a/src/tests/float.cpp
+++ b/src/tests/float.cpp
@@ -5,37 +5,61 @@
 
 #include <gtest/gtest.h>
 
+#include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+// Some tests are disabled because they are slow, especially in debug builds.
+// TODO: enable this option with fuzzy testing in [#88](#88) to reduce compute.
+#define ENABLE_EXPENSIVE_TESTS 0
 
 namespace
 {
 
-TEST(FloatTest, OneOverUintMax)
-{
-	EXPECT_EQ(oqmc::floatOneOverUintMax, 1.0f / static_cast<float>(UINT32_MAX));
-}
+const auto floatOneMinusEpsilon = std::nextafterf(1.0f, 0.0f);
 
-TEST(FloatTest, OneMinusEpsilon)
+TEST(FloatTest, OneOverTwoPower32)
 {
-	EXPECT_EQ(oqmc::floatOneMinusEpsilon, std::nextafter(1.0f, 0.0f));
+	constexpr auto twoPow32 = 1ull << 32; // 2^32
+
+	EXPECT_EQ(oqmc::floatOneOverTwoPower32, 1.0f / twoPow32);
 }
 
 TEST(FloatTest, Minimum)
 {
 	EXPECT_EQ(oqmc::uintToFloat(0u), 0.0f);
 	EXPECT_GT(oqmc::uintToFloat(1u), 0.0f);
+	EXPECT_LT(oqmc::uintToFloat(1u), oqmc::uintToFloat(2u));
 }
 
 TEST(FloatTest, Maximum)
 {
-	EXPECT_EQ(oqmc::uintToFloat(UINT32_MAX), oqmc::floatOneMinusEpsilon);
+	EXPECT_EQ(oqmc::uintToFloat(UINT32_MAX), floatOneMinusEpsilon);
 }
 
-TEST(FloatTest, HalfValue)
+TEST(FloatTest, High)
 {
-	// Note that due to floating point rounding, this rounds up to 0.5 value.
-	EXPECT_EQ(oqmc::uintToFloat(UINT32_MAX / 2), 0.5f);
+	// Exactly 256 input values [0xffffff00, 0xffffffff] output
+	// floatOneMinusEpsilon.
+	EXPECT_LT(oqmc::uintToFloat(0xfffffeff), floatOneMinusEpsilon);
+	EXPECT_EQ(oqmc::uintToFloat(0xffffff00), floatOneMinusEpsilon);
+	EXPECT_EQ(oqmc::uintToFloat(0xffffff01), floatOneMinusEpsilon);
+	EXPECT_EQ(oqmc::uintToFloat(0xffffffff), floatOneMinusEpsilon);
+}
+
+TEST(FloatTest, Half)
+{
+	// Exactly 256 input values [0x80000000, 0x800000ff] output 0.5
+	EXPECT_LT(oqmc::uintToFloat(0x7fffffff), 0.5f);
+	EXPECT_EQ(oqmc::uintToFloat(0x80000000), 0.5f);
+	EXPECT_EQ(oqmc::uintToFloat(0x80000001), 0.5f);
+	EXPECT_EQ(oqmc::uintToFloat(0x800000ff), 0.5f);
+	EXPECT_GT(oqmc::uintToFloat(0x80000100), 0.5f);
 }
 
 TEST(FloatTest, Monotonic)
@@ -54,5 +78,158 @@ TEST(FloatTest, Monotonic)
 		lastValue = stepFloat;
 	}
 }
+
+#if ENABLE_EXPENSIVE_TESTS
+TEST(FloatTest, Equidistributed)
+{
+	// Verify that oqmc::uintToFloat() produces a distribution over floats
+	// proportional to their representational density. That is, each output
+	// float has the correct number of input integers mapping to it.
+	//
+	// This is equivalent to requiring that, within each power-of-two interval,
+	// all outputs have equal probability.
+	//
+	// For example, every unique output in [0.5, 1.0) has probability 2^-24
+	// and corresponds to exactly 256 inputs.
+
+	// Use 64-bit integer to prevent overflow on loop upper bounds.
+	using uint64_t = std::uint64_t;
+
+	// Check each power of two in [0,32) corresponding to
+	// input range [min,max), where min=2^P and max=2*min.
+	for(int power = 0; power < 32; ++power)
+	{
+		uint64_t min = 1ull << power;
+		uint64_t max = min * 2;
+
+		// For each power of two in the range [0,24) there is exactly one
+		// output for each input.
+		unsigned repeats = 1;
+
+		// For each power of two in the range [24,31) there are multiple inputs
+		// that correspond to each output, with a repeat factor of 2^(P-23).
+		if(power >= 24)
+		{
+			repeats = 1ull << (power - 23);
+		}
+
+		// Check each range of inputs that map to the same output
+		for(uint64_t input = min; input < max; input += repeats)
+		{
+			auto previous = oqmc::uintToFloat(input - 1);
+			auto current = oqmc::uintToFloat(input);
+
+			// Check output of current range equals the expected value,
+			// when calculated with exact arithmetic (double is sufficient).
+			auto expected = ldexp(static_cast<double>(input), -32);
+			EXPECT_EQ(current, expected);
+
+			// Check output of current range is greater than previous
+			EXPECT_LT(previous, current);
+
+			// Check every input in the range has same output
+			for(uint64_t repeat = 0; repeat < repeats; ++repeat)
+			{
+				EXPECT_EQ(oqmc::uintToFloat(input + repeat), current);
+			}
+		}
+	}
+}
+#endif
+
+TEST(FloatTest, PowersOfTwo)
+{
+	// All inputs that are powers of two should map to an output
+	// that exactly equals the expected power of two.
+
+	for(int i = 0; i < 32; i++)
+	{
+		std::uint32_t input = 1u << i;
+		auto inputFloat = static_cast<float>(input);
+
+		auto expect = inputFloat * oqmc::floatOneOverTwoPower32;
+		auto actual = oqmc::uintToFloat(input);
+		EXPECT_EQ(actual, expect);
+	}
+}
+
+float bitsToFloat(std::uint32_t value)
+{
+	float out;
+	std::memcpy(&out, &value, sizeof(std::uint32_t));
+
+	return out;
+}
+
+TEST(FloatTest, BitsToFloat)
+{
+	EXPECT_EQ(bitsToFloat(0u), +0.0f);
+	EXPECT_EQ(bitsToFloat(1u << 31), -0.0f);
+	EXPECT_EQ(bitsToFloat(1u), std::nextafterf(0.0f, 1.0f));
+	EXPECT_EQ(bitsToFloat(0x7F << 23), 1.0f);
+}
+
+int countLeadingZeros(std::uint32_t value)
+{
+	assert(value > 0);
+
+#if defined(_MSC_VER)
+	auto index = 0ul;
+	_BitScanReverse(&index, value);
+
+	return 31 - index;
+#else
+	return __builtin_clz(value);
+#endif
+}
+
+TEST(FloatTest, CountLeadingZeros)
+{
+	EXPECT_EQ(countLeadingZeros(1u), 31);
+	EXPECT_EQ(countLeadingZeros(UINT32_MAX), 0);
+	EXPECT_EQ(countLeadingZeros(1u << 31 >> 7 | 1u), 7);
+}
+
+#if ENABLE_EXPENSIVE_TESTS
+// Reference implementation of method detailed in Section 2.1 of
+// 'Quasi-Monte Carlo Algorithms (not only) for Graphics Software'
+// by Keller, Wächter and Binder.
+float uintToFloatReference(std::uint32_t value)
+{
+	if(value == 0)
+	{
+		return 0.0f;
+	}
+
+	if(value == 1)
+	{
+		return bitsToFloat(0x5F << 23);
+	}
+
+	const auto clz = countLeadingZeros(value);
+	const auto bias = static_cast<std::uint32_t>(127);
+
+	// Shift an extra bit as implicit leading one.
+	const auto mantissa = value << (clz + 1);
+	const auto exponent = bias - (clz + 1);
+
+	return bitsToFloat(exponent << 23 | mantissa >> 9);
+}
+
+TEST(FloatTest, MatchReference)
+{
+	auto i = 0u;
+
+	while(true)
+	{
+		EXPECT_EQ(oqmc::uintToFloat(i), uintToFloatReference(i));
+
+		if(i++ == UINT32_MAX)
+		{
+			break;
+		}
+	}
+}
+#endif
 
 } // namespace


### PR DESCRIPTION
Conversion from an integer value across the full range of representable values to floating point values within the range of [0, 1) is a key part to QMC algorithms, as most calculations are done using integer arithmetic, but the resulting output often needs to be floating point.

The current implementation uses a standard conversion to float followed by a division by 2^32. However, the operation uses default rounding mode (round nearest) and therefore may round either up or down. This produces uneven probabilities across the final distribution of values within the representable range. Rounding up also means a value of exactly 1 may generated. Due to this, a min operation is used to clamp all values to the last representable number before 1, which also adds bias.

The high-quality mapping presented in 'Quasi-Monte Carlo Algorithms (not only) for Graphics Software' by Keller Wächter and Binder provides an optimal distribution, but this is computationally more expensive and often costs more than the creation of the QMC point.

This patch implements a new method that is simpler and more efficient, while providing identical results to the Keller et al method. A simple bitwise shift and mask operation is applied to the input integer to ensure that the value is rounded down. This guarantees that the probability of each output is equal to the density of float representations, and constant in each power of two. For example, every float in [0.5, 1.0) has a 2^-24 probability and is produced by exactly 256 input values.

(Issue 84)