### PR TITLE
Update the development roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,10 +1063,11 @@ domains, which might not be used.
 ## Development roadmap
 
 <!-- MKDOCS_SPLIT: roadmap.md -->
-Roadmap for version 1.0.0 of the library:
+Roadmap for the project:
 
-- Gather feedback and iterate on API.
-- Add support for package managers.
+- Grow contributors, adopters and industry representation on the TSC.
+- Provide broader access via C-ABI and Python bindings.
+- Achieve the OpenSSF Passing badge.
 <!-- MKDOCS_SPLIT_END -->
 
 ## Developer workflow


### PR DESCRIPTION
The roadmap items were scoped to a 1.0.0 release and no longer reflect the current direction of the project.

Replace the previous two items with three goals covering community and TSC growth, C-ABI and Python bindings, and the OpenSSF Passing badge. Drop the version framing so the section reads as project goals rather than a release checklist.