### PR TITLE
Warm up the device before benchmark timings

### DIFF
--- a/src/tools/lib/benchmark.cpp
+++ b/src/tools/lib/benchmark.cpp
@@ -87,6 +87,9 @@ bool run(const char* measurement, int nsamples, int ndims, int* out)
 	void* cache;
 	OQMC_ALLOCATE(&cache, Sampler::cacheSize);
 
+	// Warm up, so one time device setup is not timed below.
+	OQMC_LAUNCH(kernal<Sampler>, 0, 0, cache);
+
 	const auto timeInit =
 	    benchmark([cache]() { Sampler::initialiseCache(cache); });
 


### PR DESCRIPTION
On a GPU build, `benchmark sobol samples` and `benchmark lattice samples` measure one time CUDA context creation rather than the sampler, as reported in #109. Neither sampler allocates a cache, so nothing touches the device until the timed launch.

The solution is to launch the kernel once with a sample count of zero ahead of both measurements. The loop body never runs, so this only creates the context. RTX 4070 Laptop, Release, median of three runs, microseconds:

| sampler | before | after |
|---------|-------:|------:|
| sobol   | 133457 |   349 |
| lattice | 131444 |   119 |

`sobolbn`, `latticebn`, `pmj` and `pmjbn` are unchanged, as their managed cache allocation already creates the context ahead of both timers.

Closes #109.