### PR TITLE
Fix doxygen check on CI

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v25
-      - run: curl -L -O https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.4.0/doxygen-awesome.css
-      - run: curl -L -O https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.4.0/doxygen-awesome-sidebar-only.css
       - run: nix develop -ic scripts/check-documentation.sh
 
   install:

--- a/.justfile
+++ b/.justfile
@@ -41,7 +41,7 @@
 
 # build docs
 @docs:
-  doxygen
+  scripts/check-documentation.sh
 
 # remove build and reset
 @clean:

--- a/Doxyfile
+++ b/Doxyfile
@@ -518,7 +518,7 @@ TIMESTAMP              = NO
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.


### PR DESCRIPTION
Even though doxygen is run on the CI to validate all code is documented, the check isn't working because WARNING config settings in the Doxyfile are ignored due to EXTRACT_ALL being enabled.

Disable EXTRACT_ALL to renable doc checks in the CI. Also clean up the just recipes and CI around how the template files are downloaded.